### PR TITLE
Use Tor's binutils/gcc (not Wheezy's) for Go projects that use cgo

### DIFF
--- a/keyring/binutils.gpg
+++ b/keyring/binutils.gpg
@@ -1,0 +1,1 @@
+../tor-browser-build/keyring/binutils.gpg

--- a/projects/binutils
+++ b/projects/binutils
@@ -1,0 +1,1 @@
+../tor-browser-build/projects/binutils

--- a/projects/gcc
+++ b/projects/gcc
@@ -1,0 +1,1 @@
+../tor-browser-build/projects/gcc

--- a/projects/github.com,coreos,go-systemd/config
+++ b/projects/github.com,coreos,go-systemd/config
@@ -12,8 +12,23 @@ var:
   go_lib_install:
     - github.com/coreos/go-systemd/journal
   go_lib_deps: []
+  build_go_lib_pre: |
+    [% IF c("var/linux") %]
+      [% pc(c('var/compiler'), 'var/setup', { compiler_tarfile => c('input_files_by_name/' _ c('var/compiler')) }) %]
+
+      tar -C /var/tmp/dist -xf $rootdir/[% c('input_files_by_name/binutils') %]
+      export PATH="/var/tmp/dist/binutils/bin:$PATH"
+
+      export CGO_ENABLED=1
+    [% END -%]
 
 input_files:
   - project: container-image
   - name: go
     project: go
+  - name: '[% c("var/compiler") %]'
+    project: '[% c("var/compiler") %]'
+    enable: '[% c("var/linux") %]'
+  - name: binutils
+    project: binutils
+    enable: '[% c("var/linux") %]'

--- a/projects/github.com,hlandau,buildinfo/config
+++ b/projects/github.com,hlandau,buildinfo/config
@@ -11,10 +11,25 @@ var:
   go_lib: github.com/hlandau/buildinfo
   go_lib_deps:
     - gopkg.in,hlandau,easyconfig.v1
+  build_go_lib_pre: |
+    [% IF c("var/linux") %]
+      [% pc(c('var/compiler'), 'var/setup', { compiler_tarfile => c('input_files_by_name/' _ c('var/compiler')) }) %]
+
+      tar -C /var/tmp/dist -xf $rootdir/[% c('input_files_by_name/binutils') %]
+      export PATH="/var/tmp/dist/binutils/bin:$PATH"
+
+      export CGO_ENABLED=1
+    [% END -%]
 
 input_files:
   - project: container-image
   - name: go
     project: go
+  - name: '[% c("var/compiler") %]'
+    project: '[% c("var/compiler") %]'
+    enable: '[% c("var/linux") %]'
+  - name: binutils
+    project: binutils
+    enable: '[% c("var/linux") %]'
   - name: gopkg.in,hlandau,easyconfig.v1
     project: gopkg.in,hlandau,easyconfig.v1

--- a/projects/github.com,hlandau,dexlogconfig/config
+++ b/projects/github.com,hlandau,dexlogconfig/config
@@ -14,11 +14,26 @@ var:
     - gopkg.in,hlandau,easyconfig.v1
     - github.com,coreos,go-systemd
     - github.com,hlandau,buildinfo
+  build_go_lib_pre: |
+    [% IF c("var/linux") %]
+      [% pc(c('var/compiler'), 'var/setup', { compiler_tarfile => c('input_files_by_name/' _ c('var/compiler')) }) %]
+
+      tar -C /var/tmp/dist -xf $rootdir/[% c('input_files_by_name/binutils') %]
+      export PATH="/var/tmp/dist/binutils/bin:$PATH"
+
+      export CGO_ENABLED=1
+    [% END -%]
 
 input_files:
   - project: container-image
   - name: go
     project: go
+  - name: '[% c("var/compiler") %]'
+    project: '[% c("var/compiler") %]'
+    enable: '[% c("var/linux") %]'
+  - name: binutils
+    project: binutils
+    enable: '[% c("var/linux") %]'
   - name: github.com,hlandau,xlog
     project: github.com,hlandau,xlog
   - name: gopkg.in,hlandau,easyconfig.v1

--- a/projects/gopkg.in,hlandau,madns.v1/config
+++ b/projects/gopkg.in,hlandau,madns.v1/config
@@ -16,11 +16,26 @@ var:
   go_lib_install:
     - gopkg.in/hlandau/madns.v1
     - gopkg.in/hlandau/madns.v1/merr
+  build_go_lib_pre: |
+    [% IF c("var/linux") %]
+      [% pc(c('var/compiler'), 'var/setup', { compiler_tarfile => c('input_files_by_name/' _ c('var/compiler')) }) %]
+
+      tar -C /var/tmp/dist -xf $rootdir/[% c('input_files_by_name/binutils') %]
+      export PATH="/var/tmp/dist/binutils/bin:$PATH"
+
+      export CGO_ENABLED=1
+    [% END -%]
 
 input_files:
   - project: container-image
   - name: go
     project: go
+  - name: '[% c("var/compiler") %]'
+    project: '[% c("var/compiler") %]'
+    enable: '[% c("var/linux") %]'
+  - name: binutils
+    project: binutils
+    enable: '[% c("var/linux") %]'
   - name: github.com,miekg,dns
     project: github.com,miekg,dns
   - name: github.com,hlandau,buildinfo

--- a/projects/gopkg.in,hlandau,service.v2/config
+++ b/projects/gopkg.in,hlandau,service.v2/config
@@ -12,9 +12,22 @@ var:
   go_lib_deps:
     - gopkg.in,hlandau,svcutils.v1
     - gopkg.in,hlandau,easyconfig.v1
+  build_go_lib_pre: |
+    [% IF c("var/linux") %]
+      [% pc(c('var/compiler'), 'var/setup', { compiler_tarfile => c('input_files_by_name/' _ c('var/compiler')) }) %]
+
+      tar -C /var/tmp/dist -xf $rootdir/[% c('input_files_by_name/binutils') %]
+      export PATH="/var/tmp/dist/binutils/bin:$PATH"
+
+      export CGO_ENABLED=1
+    [% END -%]
 
 targets:
-  linux:
+  linux-i686:
+    var:
+      arch_deps:
+        - libcap-dev:i386
+  linux-x86_64:
     var:
       arch_deps:
         - libcap-dev
@@ -23,6 +36,12 @@ input_files:
   - project: container-image
   - name: go
     project: go
+  - name: '[% c("var/compiler") %]'
+    project: '[% c("var/compiler") %]'
+    enable: '[% c("var/linux") %]'
+  - name: binutils
+    project: binutils
+    enable: '[% c("var/linux") %]'
   - name: gopkg.in,hlandau,svcutils.v1
     project: gopkg.in,hlandau,svcutils.v1
   - name: gopkg.in,hlandau,easyconfig.v1

--- a/projects/gopkg.in,hlandau,svcutils.v1/config
+++ b/projects/gopkg.in,hlandau,svcutils.v1/config
@@ -9,9 +9,22 @@ var:
   container:
     use_container: 1
   go_lib: gopkg.in/hlandau/svcutils.v1
+  build_go_lib_pre: |
+    [% IF c("var/linux") %]
+      [% pc(c('var/compiler'), 'var/setup', { compiler_tarfile => c('input_files_by_name/' _ c('var/compiler')) }) %]
+
+      tar -C /var/tmp/dist -xf $rootdir/[% c('input_files_by_name/binutils') %]
+      export PATH="/var/tmp/dist/binutils/bin:$PATH"
+
+      export CGO_ENABLED=1
+    [% END -%]
 
 targets:
-  linux:
+  linux-i686:
+    var:
+      arch_deps:
+        - libcap-dev:i386
+  linux-x86_64:
     var:
       arch_deps:
         - libcap-dev
@@ -20,3 +33,9 @@ input_files:
   - project: container-image
   - name: go
     project: go
+  - name: '[% c("var/compiler") %]'
+    project: '[% c("var/compiler") %]'
+    enable: '[% c("var/linux") %]'
+  - name: binutils
+    project: binutils
+    enable: '[% c("var/linux") %]'

--- a/projects/ncdns/build
+++ b/projects/ncdns/build
@@ -1,6 +1,14 @@
-#!/bin/sh
+#!/bin/bash
 [% c("var/set_default_env") -%]
 [% pc('go', 'var/setup', { go_tarfile => c('input_files_by_name/go') }) %]
+[% IF c("var/linux") %]
+  [% pc(c('var/compiler'), 'var/setup', { compiler_tarfile => c('input_files_by_name/' _ c('var/compiler')) }) %]
+
+  tar -C /var/tmp/dist -xf $rootdir/[% c('input_files_by_name/binutils') %]
+  export PATH="/var/tmp/dist/binutils/bin:$PATH"
+
+  export CGO_ENABLED=1
+[% END -%]
 distdir=/var/tmp/dist/[% project %]
 mkdir -p $distdir
 

--- a/projects/ncdns/config
+++ b/projects/ncdns/config
@@ -20,7 +20,11 @@ var:
     - golang.org,x,net
 
 targets:
-  linux:
+  linux-i686:
+    var:
+      arch_deps:
+        - libcap-dev:i386
+  linux-x86_64:
     var:
       arch_deps:
         - libcap-dev
@@ -29,6 +33,12 @@ input_files:
   - project: container-image
   - name: go
     project: go
+  - name: '[% c("var/compiler") %]'
+    project: '[% c("var/compiler") %]'
+    enable: '[% c("var/linux") %]'
+  - name: binutils
+    project: binutils
+    enable: '[% c("var/linux") %]'
   - name: github.com,hlandau,xlog
     project: github.com,hlandau,xlog
   - name: github.com,hlandau,dexlogconfig


### PR DESCRIPTION
This should improve reproducibility, and it might also fix whatever bugs might be caused by the ancient Wheezy binutils/gcc.