### PR TITLE
Fix windows builds

### DIFF
--- a/hashlist
+++ b/hashlist
@@ -1,5 +1,6 @@
 git github.com/alecthomas/template b867cc6ab45cece8143cfcc6fc9c77cf3f2c23c0 heads/master
 git github.com/alecthomas/units 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a heads/master
+git github.com/btcsuite/winsvc f8fb11f83f7e860e3769a08e6811d1b399a43722 tags/v1.0.0
 git github.com/BurntSushi/toml 056c9bc7be7190eaa7715723883caffa5f8fa3e4 heads/master
 git github.com/coreos/go-systemd a831f36d09de8f095c28eeee839df52e9de5031f heads/master
 git github.com/golang/groupcache 604ed5785183e59ae2789449d89e73f3a2a77987 heads/master

--- a/projects/github.com,btcsuite,winsvc/config
+++ b/projects/github.com,btcsuite,winsvc/config
@@ -1,0 +1,19 @@
+version: '[% c("abbrev") %]'
+git_url:  https://github.com/btcsuite/winsvc.git
+git_hash: '[% config.var_p.id.${"github.com/btcsuite/winsvc"} %]'
+filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
+
+build: '[% c("projects/go/var/build_go_lib") %]'
+
+var:
+  container:
+    use_container: 1
+  go_lib: github.com/btcsuite/winsvc
+  go_lib_install:
+    - github.com/btcsuite/winsvc/mgr
+    - github.com/btcsuite/winsvc/svc
+
+input_files:
+  - project: container-image
+  - name: go
+    project: go

--- a/projects/github.com,hlandau,dexlogconfig/config
+++ b/projects/github.com,hlandau,dexlogconfig/config
@@ -24,6 +24,14 @@ var:
       export CGO_ENABLED=1
     [% END -%]
 
+targets:
+  windows:
+    var:
+      go_lib_deps:
+        - github.com,hlandau,xlog
+        - gopkg.in,hlandau,easyconfig.v1
+        - github.com,hlandau,buildinfo
+
 input_files:
   - project: container-image
   - name: go
@@ -40,5 +48,6 @@ input_files:
     project: gopkg.in,hlandau,easyconfig.v1
   - name: github.com,coreos,go-systemd
     project: github.com,coreos,go-systemd
+    enable: '[% ! c("var/windows") %]'
   - name: github.com,hlandau,buildinfo
     project: github.com,hlandau,buildinfo

--- a/projects/golang.org,x,sys
+++ b/projects/golang.org,x,sys
@@ -1,0 +1,1 @@
+../tor-browser-build/projects/goxsys

--- a/projects/gopkg.in,hlandau,service.v2/config
+++ b/projects/gopkg.in,hlandau,service.v2/config
@@ -31,6 +31,12 @@ targets:
     var:
       arch_deps:
         - libcap-dev
+  windows:
+    var:
+      go_lib_deps:
+        - github.com,btcsuite,winsvc
+        - gopkg.in,hlandau,svcutils.v1
+        - gopkg.in,hlandau,easyconfig.v1
 
 input_files:
   - project: container-image
@@ -42,6 +48,9 @@ input_files:
   - name: binutils
     project: binutils
     enable: '[% c("var/linux") %]'
+  - name: github.com,btcsuite,winsvc
+    project: github.com,btcsuite,winsvc
+    enable: '[% c("var/windows") %]'
   - name: gopkg.in,hlandau,svcutils.v1
     project: gopkg.in,hlandau,svcutils.v1
   - name: gopkg.in,hlandau,easyconfig.v1

--- a/projects/mingw-w64
+++ b/projects/mingw-w64
@@ -1,0 +1,1 @@
+../tor-browser-build/projects/mingw-w64

--- a/projects/ncdns/config
+++ b/projects/ncdns/config
@@ -28,6 +28,21 @@ targets:
     var:
       arch_deps:
         - libcap-dev
+  windows:
+    var:
+      go_lib_deps:
+        - github.com,golang,groupcache
+        - github.com,hlandau,degoutils
+        - github.com,hlandau,dexlogconfig
+        - github.com,hlandau,ncbtcjsontypes
+        - github.com,hlandauf,btcjson
+        - github.com,kr,pretty
+        - github.com,miekg,dns
+        - gopkg.in,hlandau,madns.v1
+        - gopkg.in,hlandau,easyconfig.v1
+        - gopkg.in,hlandau,service.v2
+        - golang.org,x,net
+        - golang.org,x,sys
 
 input_files:
   - project: container-image
@@ -63,3 +78,6 @@ input_files:
     project: github.com,hlandau,degoutils
   - name: golang.org,x,net
     project: golang.org,x,net
+  - name: golang.org,x,sys
+    project: golang.org,x,sys
+    enable: '[% c("var/windows") %]'


### PR DESCRIPTION
This PR fixes the build errors for the `release-windows-x86_64` target.  I haven't yet tested the `release-windows-i686` target, but it's likely to benefit from these fixes too.