### PR TITLE
Add DNSSEC-HSTS

### DIFF
--- a/projects/dnssec-hsts-native/build
+++ b/projects/dnssec-hsts-native/build
@@ -1,0 +1,45 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('go', 'var/setup', { go_tarfile => c('input_files_by_name/go') }) %]
+export CGO_ENABLED=0
+distdir=/var/tmp/dist/[% project %]
+mkdir -p $distdir
+
+[% FOREACH dep = c("var/go_lib_deps") -%]
+  tar -C /var/tmp/dist -xf [% c('input_files_by_name/' _ dep) %]
+[% END -%]
+
+mkdir -p $GOPATH/src/github.com/namecoin
+tar -C $GOPATH/src/github.com/namecoin -xf [% project %]-[% c('version') %].tar.gz
+mv $GOPATH/src/github.com/namecoin/dnssec-hsts-native-[% c('version') %] $GOPATH/src/github.com/namecoin/dnssec-hsts-native
+
+go install -ldflags '-s' github.com/namecoin/dnssec-hsts-native/src/dnssec_hsts
+
+#mkdir -p /var/tmp/build
+#tar -C /var/tmp/build -xf [% project %]-[% c('version') %].tar.gz
+#cd /var/tmp/build/[% project %]-[% c('version') %]
+
+#mkdir -p "$GOPATH/src/github.com/namecoin"
+#ln -sf "$PWD" "$GOPATH/src/github.com/namecoin/ncdns"
+
+#mkdir -p out
+#cd out
+#for x in .. ../ncdumpzone ../generate_nmc_cert; do
+#  go build -ldflags '-s' "$x"
+#done
+
+[% IF c("var/linux-x86_64") -%]
+  GOPATHBIN="${GOPATH}/bin"
+[% ELSE -%]
+  GOPATHBIN="${GOPATH}/bin/${GOOS}_${GOARCH}"
+[% END -%]
+
+ls $GOPATHBIN
+
+cp -a $GOPATHBIN/dnssec_hsts[% IF c("var/windows") %].exe[% END %] $distdir/
+
+cd $distdir
+[% c('tar', {
+     tar_src   => [ '.' ],
+     tar_args  => '-czf ' _ dest_dir _ '/' _ c('filename'),
+   }) %]

--- a/projects/dnssec-hsts-native/config
+++ b/projects/dnssec-hsts-native/config
@@ -1,0 +1,28 @@
+version: '[% c("abbrev") %]'
+git_url:  https://github.com/namecoin/dnssec-hsts-native.git
+git_hash: '70cc6b40311abe70ab12a71303f69ff027dcf0f4'
+filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
+
+var:
+  container:
+    use_container: 1
+  go_lib_deps:
+    - github.com,miekg,dns
+    - github.com,namecoin,qlib
+    - gopkg.in,hlandau,easyconfig.v1
+  cgo: 0
+  build_go_lib_pre: |
+    export CGO_ENABLED=[% c("var/cgo") %] 
+
+input_files:
+  - project: container-image
+  - name: go
+    project: go
+  - name: gopkg.in,hlandau,easyconfig.v1
+    project: gopkg.in,hlandau,easyconfig.v1
+  - name: github.com,miekg,dns
+    project: github.com,miekg,dns
+    # v1.0.15 is the last tagged release that still works with q.
+    git_hash: '7064f7248f5fa5fd79382a76328b4e200b79e4ae'
+  - name: github.com,namecoin,qlib
+    project: github.com,namecoin,qlib

--- a/projects/dnssec-hsts/build
+++ b/projects/dnssec-hsts/build
@@ -1,0 +1,8 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+[% c('zip', {
+        zip_src => [ '.' ],
+        zip_args => dest_dir _ '/' _ c('filename'),
+    }) %]

--- a/projects/dnssec-hsts/config
+++ b/projects/dnssec-hsts/config
@@ -1,0 +1,11 @@
+# vim: filetype=yaml sw=2
+version: '[% c("abbrev") %]'
+git_url:  https://github.com/namecoin/dnssec-hsts.git
+git_hash: 'e24019949a8344d672591d1676a5c9ab67853fa4'
+filename: '[% project %]-[% c("version") %]-[% c("var/build_id") %].xpi'
+
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image

--- a/projects/github.com,namecoin,qlib/config
+++ b/projects/github.com,namecoin,qlib/config
@@ -1,0 +1,24 @@
+version: '[% c("abbrev") %]'
+git_url:  https://github.com/namecoin/qlib.git
+git_hash: '99c375238fe562c99a2c691c433a28f90fd15afe'
+filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
+
+build: '[% c("projects/go/var/build_go_lib") %]'
+
+var:
+  container:
+    use_container: 1
+  go_lib: github.com/namecoin/qlib
+  go_lib_deps:
+    - github.com,miekg,dns
+  build_go_lib_pre: |
+    export CGO_ENABLED=0
+
+input_files:
+  - project: container-image
+  - name: go
+    project: go
+  - name: github.com,miekg,dns
+    project: github.com,miekg,dns
+    # v1.0.15 is the last tagged release that still works with q.
+    git_hash: '7064f7248f5fa5fd79382a76328b4e200b79e4ae'


### PR DESCRIPTION
This PR adds DNSSEC-HSTS (both the WebExtensions and native components).  It also adds qlib since it's a dependency of DNSSEC-HSTS.  qexe is considered out of scope for this PR.

Fixes https://github.com/namecoin/ncdns-repro/issues/14