### PR TITLE
Add ncp11 project and its dependencies

### DIFF
--- a/hashlist
+++ b/hashlist
@@ -14,6 +14,7 @@ git github.com/kr/pretty a0c635c0aede2cb0c2f8bb0f0d70485fbdd11bd4 heads/master
 git github.com/kr/text e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f heads/master
 git github.com/mattn/go-isatty 7fcbc72f853b92b5720db4a6b8482be612daef24 heads/master
 git github.com/miekg/dns 8a56deec68a78bfea6e73db7b086175eb8beec8b heads/master
+git github.com/miekg/pkcs11 cb39313ec884f2cd77f4762875fe96aecf68f8e3 tags/v1.0.2
 git github.com/namecoin/ncdns 19534f1dcfd1151bd9c072459caac12f6fb384df tags/v0.0.6
 git github.com/ogier/pflag 45c278ab3607870051a2ea9040bb85fcb8557481 heads/master
 git github.com/shiena/ansicolor a422bbe96644373c5753384a59d678f7d261ff10 heads/master

--- a/hashlist
+++ b/hashlist
@@ -16,6 +16,7 @@ git github.com/mattn/go-isatty 7fcbc72f853b92b5720db4a6b8482be612daef24 heads/ma
 git github.com/miekg/dns 8a56deec68a78bfea6e73db7b086175eb8beec8b heads/master
 git github.com/miekg/pkcs11 cb39313ec884f2cd77f4762875fe96aecf68f8e3 tags/v1.0.2
 git github.com/namecoin/ncdns 19534f1dcfd1151bd9c072459caac12f6fb384df tags/v0.0.6
+git github.com/namecoin/pkcs11mod f7dce61fc5379851e99cfa2111834a29e3d36305 heads/master
 git github.com/ogier/pflag 45c278ab3607870051a2ea9040bb85fcb8557481 heads/master
 git github.com/shiena/ansicolor a422bbe96644373c5753384a59d678f7d261ff10 heads/master
 git golang.org/x/net e0c57d8f86c17f0724497efcb3bc617e82834821 heads/master

--- a/projects/github.com,miekg,pkcs11/config
+++ b/projects/github.com,miekg,pkcs11/config
@@ -1,0 +1,42 @@
+version: '[% c("abbrev") %]'
+git_url:  https://github.com/miekg/pkcs11.git
+git_hash: '[% config.var_p.id.${"github.com/miekg/pkcs11"} %]'
+filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
+
+build: '[% c("projects/go/var/build_go_lib") %]'
+
+var:
+  container:
+    use_container: 1
+  go_lib: github.com/miekg/pkcs11
+  cgo: 1
+  build_go_lib_pre: |
+    [% IF c("var/cgo") %]
+      [% pc(c('var/compiler'), 'var/setup', { compiler_tarfile => c('input_files_by_name/' _ c('var/compiler')) }) %]
+
+      [% IF c("var/linux") %]
+        tar -C /var/tmp/dist -xf $rootdir/[% c('input_files_by_name/binutils') %]
+        export PATH="/var/tmp/dist/binutils/bin:$PATH"
+      [% END -%]
+
+      [% IF c("var/osx") -%]
+        export CGO_CFLAGS="[% c("var/FLAGS") %] -mmacosx-version-min=10.7"
+        export CGO_CXXFLAGS="[% c("var/FLAGS") %] -stdlib=libc++ -mmacosx-version-min=10.7"
+        export CGO_LDFLAGS="[% c("var/FLAGS") %] -stdlib=libc++ -mmacosx-version-min=10.7"
+        export CC="$clangdir/bin/clang"
+        export CXX="$clangdir/bin/clang++"
+      [% END -%]
+    [% END -%]
+
+    export CGO_ENABLED=[% c("var/cgo") %]
+
+input_files:
+  - project: container-image
+  - name: go
+    project: go
+  - name: '[% c("var/compiler") %]'
+    project: '[% c("var/compiler") %]'
+    enable: '[% c("var/cgo") %]'
+  - name: binutils
+    project: binutils
+    enable: '[% c("var/linux") && c("var/cgo") %]'

--- a/projects/github.com,namecoin,pkcs11mod/config
+++ b/projects/github.com,namecoin,pkcs11mod/config
@@ -1,0 +1,56 @@
+version: '[% c("abbrev") %]'
+git_url:  https://github.com/namecoin/pkcs11mod.git
+git_hash: '[% config.var_p.id.${"github.com/namecoin/pkcs11mod"} %]'
+filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
+
+build: '[% c("projects/go/var/build_go_lib") %]'
+
+var:
+  container:
+    use_container: 1
+  go_lib: github.com/namecoin/pkcs11mod
+  go_lib_deps:
+    - github.com,miekg,pkcs11
+  cgo: 1
+  build_go_lib_pre: |
+    [% IF c("var/cgo") %]
+      [% pc(c('var/compiler'), 'var/setup', { compiler_tarfile => c('input_files_by_name/' _ c('var/compiler')) }) %]
+
+      [% IF c("var/linux") %]
+        tar -C /var/tmp/dist -xf $rootdir/[% c('input_files_by_name/binutils') %]
+        export PATH="/var/tmp/dist/binutils/bin:$PATH"
+
+        # The pkcs11mod Makefile wants to see CC
+        export CC="$(go env CC)"
+      [% END -%]
+
+      [% IF c("var/osx") -%]
+        export CGO_CFLAGS="[% c("var/FLAGS") %] -mmacosx-version-min=10.7"
+        export CGO_CXXFLAGS="[% c("var/FLAGS") %] -stdlib=libc++ -mmacosx-version-min=10.7"
+        export CGO_LDFLAGS="[% c("var/FLAGS") %] -stdlib=libc++ -mmacosx-version-min=10.7"
+        export CC="$clangdir/bin/clang"
+        export CXX="$clangdir/bin/clang++"
+      [% END -%]
+
+      [% IF c("var/windows") %]
+        # The pkcs11mod Makefile wants to see CC
+        export CC="$(go env CC)"
+      [% END -%]
+    [% END -%]
+
+    export CGO_ENABLED=[% c("var/cgo") %]
+
+    go generate [% c("var/go_lib") %]
+
+input_files:
+  - project: container-image
+  - name: go
+    project: go
+  - name: '[% c("var/compiler") %]'
+    project: '[% c("var/compiler") %]'
+    enable: '[% c("var/cgo") %]'
+  - name: binutils
+    project: binutils
+    enable: '[% c("var/linux") && c("var/cgo") %]'
+  - name: github.com,miekg,pkcs11
+    project: github.com,miekg,pkcs11

--- a/projects/ncp11/build
+++ b/projects/ncp11/build
@@ -1,0 +1,70 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('go', 'var/setup', { go_tarfile => c('input_files_by_name/go') }) %]
+[% IF c("var/cgo") %]
+  [% pc(c('var/compiler'), 'var/setup', { compiler_tarfile => c('input_files_by_name/' _ c('var/compiler')) }) %]
+
+  [% IF c("var/linux") %]
+    tar -C /var/tmp/dist -xf $rootdir/[% c('input_files_by_name/binutils') %]
+    export PATH="/var/tmp/dist/binutils/bin:$PATH"
+  [% END -%]
+
+  [% IF c("var/osx") -%]
+    export CGO_CFLAGS="[% c("var/FLAGS") %] -mmacosx-version-min=10.7"
+    export CGO_CXXFLAGS="[% c("var/FLAGS") %] -stdlib=libc++ -mmacosx-version-min=10.7"
+    export CGO_LDFLAGS="[% c("var/FLAGS") %] -stdlib=libc++ -mmacosx-version-min=10.7"
+    export CC="$clangdir/bin/clang"
+    export CXX="$clangdir/bin/clang++"
+  [% END -%]
+[% END -%]
+export CGO_ENABLED=[% c("var/cgo") %]
+distdir=/var/tmp/dist/[% project %]
+mkdir -p $distdir
+
+[% FOREACH dep = c("var/go_lib_deps") -%]
+  tar -C /var/tmp/dist -xf [% c('input_files_by_name/' _ dep) %]
+[% END -%]
+
+mkdir -p $GOPATH/src/github.com/namecoin
+tar -C $GOPATH/src/github.com/namecoin -xf [% project %]-[% c('version') %].tar.gz
+mv $GOPATH/src/github.com/namecoin/ncp11-[% c('version') %] $GOPATH/src/github.com/namecoin/ncp11
+
+go install -ldflags '-s' -buildmode c-shared github.com/namecoin/ncp11
+
+#mkdir -p /var/tmp/build
+#tar -C /var/tmp/build -xf [% project %]-[% c('version') %].tar.gz
+#cd /var/tmp/build/[% project %]-[% c('version') %]
+
+#mkdir -p "$GOPATH/src/github.com/namecoin"
+#ln -sf "$PWD" "$GOPATH/src/github.com/namecoin/ncdns"
+
+#mkdir -p out
+#cd out
+#for x in .. ../ncdumpzone ../generate_nmc_cert; do
+#  go build -ldflags '-s' "$x"
+#done
+
+[% IF c("var/linux") %]
+  BUILTPATH=${GOPATH}/pkg/${GOOS}_${GOARCH}_shared/github.com/namecoin/ncp11.a
+[% ELSE -%]
+  BUILTPATH=${GOPATH}/pkg/${GOOS}_${GOARCH}/github.com/namecoin/ncp11.a
+[% END -%]
+
+[% IF c("var/linux") %]
+  OUTFILE=libncp11.so
+[% ELSIF c("var/osx") -%]
+  OUTFILE=libncp11.dylib
+[% ELSIF c("var/windows") -%]
+  OUTFILE=ncp11.dll
+[% ELSE -%]
+  echo "Unsupported OS; this might not work properly"
+  OUTFILE=libncp11.so
+[% END -%]
+
+cp -a ${BUILTPATH} $distdir/$OUTFILE
+
+cd $distdir
+[% c('tar', {
+     tar_src   => [ '.' ],
+     tar_args  => '-czf ' _ dest_dir _ '/' _ c('filename'),
+   }) %]

--- a/projects/ncp11/config
+++ b/projects/ncp11/config
@@ -1,0 +1,27 @@
+version: '[% c("abbrev") %]'
+git_url: https://github.com/namecoin/ncp11.git
+git_hash: f060446368cc5d754da04a5663982b2098705a4a
+filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
+
+var:
+  container:
+    use_container: 1
+  go_lib_deps:
+    - github.com,miekg,pkcs11
+    - github.com,namecoin,pkcs11mod
+  cgo: 1
+
+input_files:
+  - project: container-image
+  - name: go
+    project: go
+  - name: '[% c("var/compiler") %]'
+    project: '[% c("var/compiler") %]'
+    enable: '[% c("var/cgo") %]'
+  - name: binutils
+    project: binutils
+    enable: '[% c("var/linux") && c("var/cgo") %]'
+  - name: github.com,miekg,pkcs11
+    project: github.com,miekg,pkcs11
+  - name: github.com,namecoin,pkcs11mod
+    project: github.com,namecoin,pkcs11mod


### PR DESCRIPTION
Fixes https://github.com/namecoin/ncdns-repro/issues/10 .  Fixes https://github.com/namecoin/ncdns-repro/issues/16 .

~~Only tested on GNU/Linux targets.  Windows definitely won't work yet due to an ncp11/pkcs11mod bug that's out of scope for this PR.~~  GNU/Linux and Windows now both work.  macOS is untested.

TODO:

- [x] Merge https://github.com/namecoin/ncdns-repro/pull/23 first (this PR will then need a rebase).
- [x] Finalize the commits marked (WIP).