### PR TITLE
Add certdehydrate-dane-rest-api and its dependencies

### DIFF
--- a/projects/certdehydrate-dane-rest-api/build
+++ b/projects/certdehydrate-dane-rest-api/build
@@ -1,0 +1,51 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('go', 'var/setup', { go_tarfile => c('input_files_by_name/go') }) %]
+export CGO_ENABLED=0
+distdir=/var/tmp/dist/[% project %]
+mkdir -p $distdir
+
+[% FOREACH dep = c("var/go_lib_deps") -%]
+  tar -C /var/tmp/dist -xf [% c('input_files_by_name/' _ dep) %]
+[% END -%]
+
+# Workaround for mixed versions of miekg/dns
+# TODO: remove this once upstream q is fixed for current dns versions
+rm -rf $GOPATH/src/github.com/miekg/dns
+rm -rf $GOPATH/pkg/${GOOS}_${GOARCH}/github.com/miekg/dns.a
+tar -C /var/tmp/dist -xf [% c('input_files_by_name/github.com,miekg,dns') %]
+
+mkdir -p $GOPATH/src/github.com/namecoin
+tar -C $GOPATH/src/github.com/namecoin -xf [% project %]-[% c('version') %].tar.gz
+mv $GOPATH/src/github.com/namecoin/certdehydrate-dane-rest-api-[% c('version') %] $GOPATH/src/github.com/namecoin/certdehydrate-dane-rest-api
+
+go install -ldflags '-s' github.com/namecoin/certdehydrate-dane-rest-api
+
+#mkdir -p /var/tmp/build
+#tar -C /var/tmp/build -xf [% project %]-[% c('version') %].tar.gz
+#cd /var/tmp/build/[% project %]-[% c('version') %]
+
+#mkdir -p "$GOPATH/src/github.com/namecoin"
+#ln -sf "$PWD" "$GOPATH/src/github.com/namecoin/ncdns"
+
+#mkdir -p out
+#cd out
+#for x in .. ../ncdumpzone ../generate_nmc_cert; do
+#  go build -ldflags '-s' "$x"
+#done
+
+[% IF c("var/linux-x86_64") -%]
+  GOPATHBIN="${GOPATH}/bin"
+[% ELSE -%]
+  GOPATHBIN="${GOPATH}/bin/${GOOS}_${GOARCH}"
+[% END -%]
+
+ls $GOPATHBIN
+
+cp -a $GOPATHBIN/certdehydrate-dane-rest-api[% IF c("var/windows") %].exe[% END %] $distdir/
+
+cd $distdir
+[% c('tar', {
+     tar_src   => [ '.' ],
+     tar_args  => '-czf ' _ dest_dir _ '/' _ c('filename'),
+   }) %]

--- a/projects/certdehydrate-dane-rest-api/config
+++ b/projects/certdehydrate-dane-rest-api/config
@@ -1,0 +1,34 @@
+version: '[% c("abbrev") %]'
+git_url:  https://github.com/namecoin/certdehydrate-dane-rest-api.git
+git_hash: '2eeb272f4bb7dffc13e39a609b308656a5a121ea'
+filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
+
+var:
+  container:
+    use_container: 1
+  go_lib_deps:
+    - github.com,miekg,dns
+    - github.com,namecoin,crosssign
+    - github.com,namecoin,qlib
+    - github.com,namecoin,safetlsa
+    - gopkg.in,hlandau,easyconfig.v1
+  cgo: 0
+  build_go_lib_pre: |
+    export CGO_ENABLED=[% c("var/cgo") %] 
+
+input_files:
+  - project: container-image
+  - name: go
+    project: go
+  - name: gopkg.in,hlandau,easyconfig.v1
+    project: gopkg.in,hlandau,easyconfig.v1
+  - name: github.com,miekg,dns
+    project: github.com,miekg,dns
+    # v1.0.15 is the last tagged release that still works with q.
+    git_hash: '7064f7248f5fa5fd79382a76328b4e200b79e4ae'
+  - name: github.com,namecoin,crosssign
+    project: github.com,namecoin,crosssign
+  - name: github.com,namecoin,qlib
+    project: github.com,namecoin,qlib
+  - name: github.com,namecoin,safetlsa
+    project: github.com,namecoin,safetlsa

--- a/projects/certdehydrate-dane-rest-api/config
+++ b/projects/certdehydrate-dane-rest-api/config
@@ -24,8 +24,8 @@ input_files:
     project: gopkg.in,hlandau,easyconfig.v1
   - name: github.com,miekg,dns
     project: github.com,miekg,dns
-    # v1.0.15 is the last tagged release that still works with q.
-    git_hash: '7064f7248f5fa5fd79382a76328b4e200b79e4ae'
+    var:
+      dns_q_compat: 1
   - name: github.com,namecoin,crosssign
     project: github.com,namecoin,crosssign
   - name: github.com,namecoin,qlib

--- a/projects/dnssec-hsts-native/config
+++ b/projects/dnssec-hsts-native/config
@@ -22,7 +22,7 @@ input_files:
     project: gopkg.in,hlandau,easyconfig.v1
   - name: github.com,miekg,dns
     project: github.com,miekg,dns
-    # v1.0.15 is the last tagged release that still works with q.
-    git_hash: '7064f7248f5fa5fd79382a76328b4e200b79e4ae'
+    var:
+      dns_q_compat: 1
   - name: github.com,namecoin,qlib
     project: github.com,namecoin,qlib

--- a/projects/github.com,miekg,dns/config
+++ b/projects/github.com,miekg,dns/config
@@ -1,6 +1,7 @@
 version: '[% c("abbrev") %]'
 git_url:  https://github.com/miekg/dns.git
-git_hash: '[% config.var_p.id.${"github.com/miekg/dns"} %]'
+# v1.0.15 is the last tagged release that still works with q.
+git_hash: '[% IF !c("var/dns_q_compat") -%][% config.var_p.id.${"github.com/miekg/dns"} %][% ELSE %]7064f7248f5fa5fd79382a76328b4e200b79e4ae[% END %]'
 filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
 
 build: '[% c("projects/go/var/build_go_lib") %]'

--- a/projects/github.com,namecoin,crosssign/config
+++ b/projects/github.com,namecoin,crosssign/config
@@ -1,0 +1,18 @@
+version: '[% c("abbrev") %]'
+git_url:  https://github.com/namecoin/crosssign.git
+git_hash: '44408047169ecb5b56346855e0bc931a06872eb0'
+filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
+
+build: '[% c("projects/go/var/build_go_lib") %]'
+
+var:
+  container:
+    use_container: 1
+  go_lib: github.com/namecoin/crosssign
+  build_go_lib_pre: |
+    export CGO_ENABLED=0
+
+input_files:
+  - project: container-image
+  - name: go
+    project: go

--- a/projects/github.com,namecoin,qlib/config
+++ b/projects/github.com,namecoin,qlib/config
@@ -20,5 +20,5 @@ input_files:
     project: go
   - name: github.com,miekg,dns
     project: github.com,miekg,dns
-    # v1.0.15 is the last tagged release that still works with q.
-    git_hash: '7064f7248f5fa5fd79382a76328b4e200b79e4ae'
+    var:
+      dns_q_compat: 1

--- a/projects/github.com,namecoin,safetlsa/config
+++ b/projects/github.com,namecoin,safetlsa/config
@@ -1,0 +1,29 @@
+version: '[% c("abbrev") %]'
+git_url:  https://github.com/namecoin/safetlsa.git
+git_hash: '818ee2aef753c7f761cd26fbc5e4fde015f66b70'
+filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
+
+build: '[% c("projects/go/var/build_go_lib") %]'
+
+var:
+  container:
+    use_container: 1
+  go_lib: github.com/namecoin/safetlsa
+  go_lib_deps:
+    - github.com,miekg,dns
+    - ncdns
+  build_go_lib_pre: |
+    export CGO_ENABLED=0
+
+input_files:
+  - project: container-image
+  - name: go
+    project: go
+  - name: github.com,miekg,dns
+    project: github.com,miekg,dns
+  - name: ncdns
+    project: ncdns
+    # Build ncdns as a library, not an executable.
+    # TODO: refactor this once our build_go_lib executable patch is merged by upstream Tor
+    var:
+      go_lib_no_output: 0

--- a/projects/ncdns/build
+++ b/projects/ncdns/build
@@ -51,14 +51,24 @@ go install -ldflags '-s' github.com/namecoin/ncdns/...
   GOPATHBIN="${GOPATH}/bin/${GOOS}_${GOARCH}"
 [% END -%]
 
-ls $GOPATHBIN
+cd /var/tmp/dist
+[% IF !c("var/go_lib_no_output") -%]
+  # Build as library
+  [% c('tar', {
+    tar_src => [ 'gopath' ],
+    tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+  }) %]
+[% ELSE %]
+  # Build as executable
+  ls $GOPATHBIN
 
-for x in ncdns ncdumpzone ncdt generate_nmc_cert tlsrestrict_chromium_tool; do
-  cp -a $GOPATHBIN/"$x"[% IF c("var/windows") %].exe[% END %] $distdir/
-done
+  for x in ncdns ncdumpzone ncdt generate_nmc_cert tlsrestrict_chromium_tool; do
+    cp -a $GOPATHBIN/"$x"[% IF c("var/windows") %].exe[% END %] $distdir/
+  done
 
-cd $distdir
-[% c('tar', {
+  cd $distdir
+  [% c('tar', {
      tar_src   => [ '.' ],
      tar_args  => '-czf ' _ dest_dir _ '/' _ c('filename'),
    }) %]
+[% END %]

--- a/projects/ncdns/config
+++ b/projects/ncdns/config
@@ -18,6 +18,7 @@ var:
     - gopkg.in,hlandau,easyconfig.v1
     - gopkg.in,hlandau,service.v2
     - golang.org,x,net
+  go_lib_no_output: 1
 
 targets:
   linux:


### PR DESCRIPTION
Fixes https://github.com/namecoin/ncdns-repro/issues/11 .  Fixes https://github.com/namecoin/ncdns-repro/issues/13 .  Fixes https://github.com/namecoin/ncdns-repro/issues/17 .

Only tested on GNU/Linux x86_64 target.  Other targets are likely to work fine.

TODO:

- [x] Merge https://github.com/namecoin/ncdns-repro/pull/27 first (this PR will then need a rebase).