### PR TITLE
Build Electrum-NMC from source

### DIFF
--- a/keyring/python.gpg
+++ b/keyring/python.gpg
@@ -1,0 +1,1 @@
+../tor-browser-build/keyring/python.gpg

--- a/projects/aiohttp/build
+++ b/projects/aiohttp/build
@@ -1,0 +1,22 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/[% project %]-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+mkdir -p ./[% project %]
+cp -a /var/tmp/build/sdist/[% project %]/[% project %]*/[% project %]/*.py ./[% project %]/
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/aiohttp/config
+++ b/projects/aiohttp/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 3.5.4
+git_url: https://github.com/aio-libs/aiohttp.git
+git_hash: f6f647eb828fa738610d61481f11fa51e42599e9
+# TODO: This Git repo doesn't use GPG sigs.  We should pester them about that.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/aiohttp_socks/build
+++ b/projects/aiohttp_socks/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/[% project %]-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+cp -a /var/tmp/build/sdist/[% project %]/[% project %]*/[% project %] ./[% project %]
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/aiohttp_socks/config
+++ b/projects/aiohttp_socks/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 0.2.2
+git_url: https://github.com/romis2012/aiohttp-socks.git
+git_hash: 3252f4bdd37fb9a7360481977f800189cb3e3aca
+# TODO: This Git repo doesn't use GPG sigs.  We should pester them about that.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/aiorpcx/build
+++ b/projects/aiorpcx/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/aiorpcX-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+cp -a /var/tmp/build/sdist/[% project %]/aiorpcX*/[% project %] ./[% project %]
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/aiorpcx/config
+++ b/projects/aiorpcx/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 0.18.3
+git_url: https://github.com/kyuupichan/aiorpcX.git
+git_hash: 4f39366e5dee3fd0a857e53f383c628807cd2715
+# TODO: This Git repo doesn't use GPG sigs.  We should pester them about that.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/async_timeout/build
+++ b/projects/async_timeout/build
@@ -1,0 +1,22 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/async-timeout-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+mkdir -p ./[% project %]
+cp -a /var/tmp/build/sdist/[% project %]/async-timeout*/[% project %]/*.py ./[% project %]/
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/async_timeout/config
+++ b/projects/async_timeout/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 3.0.1
+git_url: https://github.com/aio-libs/async-timeout.git
+git_hash: 992fd174a5282258228b74127914f4b8135bf30a
+# TODO: This Git repo doesn't use GPG sigs.  We should pester them about that.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/attr/build
+++ b/projects/attr/build
@@ -1,0 +1,22 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/attrs-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+mkdir -p ./[% project %]
+cp -a /var/tmp/build/sdist/[% project %]/attrs*/src/[% project %]/*.py ./[% project %]
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/attr/config
+++ b/projects/attr/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 19.1.0
+git_url: https://github.com/python-attrs/attrs.git
+git_hash: 0356f0603eb5d8d4e7bae132ab80847fff4abcfc
+# TODO: This Git repo uses GPG sigs; we should switch from commit hash to GPG verification.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/certifi/build
+++ b/projects/certifi/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/[% project %]-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+cp -a /var/tmp/build/sdist/[% project %]/[% project %]*/[% project %] ./[% project %]
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/certifi/config
+++ b/projects/certifi/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 2019.3.9
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python
+  - URL: https://files.pythonhosted.org/packages/source/c/certifi/certifi-[% c("version") %].tar.gz
+    sha256sum: b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae
+    # TODO: This package uses GPG sigs; we should switch from SHA256 hash to GPG verification.

--- a/projects/chardet/build
+++ b/projects/chardet/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/[% project %]-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+cp -a /var/tmp/build/sdist/[% project %]/[% project %]*/[% project %] ./[% project %]
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/chardet/config
+++ b/projects/chardet/config
@@ -1,0 +1,14 @@
+# vim: filetype=yaml sw=2
+version: 3.0.4
+git_url: https://github.com/chardet/chardet.git
+git_hash: 9b8c5c2fb118d76c6beeab9affd01c332732a530
+# TODO: This Git repo doesn't use GPG sigs.  We should pester them about that.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python
+

--- a/projects/colorama/build
+++ b/projects/colorama/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/[% project %]-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+cp -a /var/tmp/build/sdist/[% project %]/[% project %]*/[% project %] ./[% project %]
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/colorama/config
+++ b/projects/colorama/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 0.4.1
+git_url: https://github.com/tartley/colorama.git
+git_hash: d69f83f53c0c5aa1081d1f5eebb2dc2df6028f37
+# TODO: This Git repo doesn't use GPG sigs.  We should pester them about that.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/dns/build
+++ b/projects/dns/build
@@ -1,0 +1,26 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+shopt -s globstar
+
+unzip dnspython-[% c('version') %].zip
+cd dnspython-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/dnspython-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+mkdir ./[% project %]
+cd /var/tmp/build/sdist/[% project %]/dnspython*/[% project %]
+cp --parents **/*.py /var/tmp/dist/[% project %]/[% project %]/
+
+cd /var/tmp/dist/[% project %]
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/dns/config
+++ b/projects/dns/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 1.16.0
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python
+  - URL: https://files.pythonhosted.org/packages/source/d/dnspython/dnspython-[% c("version") %].zip
+    sha256sum: 36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01
+    # TODO: This package uses GPG sigs; we should switch from SHA256 hash to GPG verification.

--- a/projects/ecdsa/build
+++ b/projects/ecdsa/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/[% project %]-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+cp -a /var/tmp/build/sdist/[% project %]/[% project %]*/[% project %] ./[% project %]
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/ecdsa/config
+++ b/projects/ecdsa/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 0.13.2
+git_url: https://github.com/warner/python-ecdsa.git
+git_hash: bb359d32e93acc3eb4d216aff4ba0e7531599cfb
+# TODO: This Git repo doesn't use GPG sigs.  We should pester them about that.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/electrum-nmc/build
+++ b/projects/electrum-nmc/build
@@ -1,12 +1,33 @@
 #!/bin/sh
 [% c("var/set_default_env") -%]
-distdir=/var/tmp/dist/[% project %]
-mkdir /var/tmp/build
-tar -C /var/tmp/build -xf Electrum-NMC-[% c("version") %].tar.gz
-cd /var/tmp/build/Electrum-NMC-[% c("version") %]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+distdir=/var/tmp/build/[% project %]
+mkdir -p /var/tmp/build/[% project %]
+tar -C /var/tmp/build/[% project %] -xf [% project %]-[% c("version") %].tar.gz
 
-cd /var/tmp/build/
+cd /var/tmp/build/[% project %]/[% project %]-*
+
+mkdir packages
+cd packages
+
+[% FOREACH dep = ['aiohttp', 'aiohttp_socks', 'aiorpcx', 'async_timeout', 'attr', 'certifi', 'chardet', 'colorama', 'dns', 'ecdsa', 'idna', 'idna_ssl', 'jsonrpclib', 'multidict', 'pyaes', 'qdarkstyle', 'qrcode', 'six', 'typing_extensions', 'yarl'] -%]
+  tar -C . -xf $rootdir/[% c('input_files_by_name/' _ dep) %]
+[% END -%]
+
+tar -C . -xf $rootdir/[% c('input_files_by_name/protobuf') %]/python-protobuf.tar.gz
+
+cd ../
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/Electrum-NMC-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+cp -a /var/tmp/build/sdist/[% project %]/Electrum-NMC* ./Electrum-NMC-[% c('version') %]
+
 [% c('tar', {
-        tar_src => 'Electrum-NMC-' _ c("version"),
+        tar_src => '.',
         tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
         }) %]

--- a/projects/electrum-nmc/config
+++ b/projects/electrum-nmc/config
@@ -1,11 +1,56 @@
 # vim: filetype=yaml sw=2
-filename: '[% project %]-[% c("version") %]-[% c("var/build_id") %].tar.gz'
-version: 3.3.6
+filename: 'Electrum-NMC-[% c("version") %]-[% c("var/build_id") %].tar.gz'
+version: 3.3.7
+git_url: https://github.com/namecoin/electrum-nmc.git
+git_hash: 49e6c3a9ef5097a8131a006ffb9900b18aa8f8d3
+# TODO: This Git repo uses GPG sigs; we should switch from commit hash to GPG verification.
 var:
   container:
     use_container: 1
 
 input_files:
   - project: container-image
-  - URL: 'https://beta.namecoin.org/files/electrum-nmc/electrum-nmc-[% c("version") %]/Electrum-NMC-[% c("version") %].tar.gz'
-    sha256sum: 45bc7a84beece562d0b9fdb0f185a9edb0703f3aef80ab546f8ccfc2a9a21953
+  - project: python
+    name: python
+  - project: aiohttp
+    name: aiohttp
+  - project: aiohttp_socks
+    name: aiohttp_socks
+  - project: aiorpcx
+    name: aiorpcx
+  - project: async_timeout
+    name: async_timeout
+  - project: attr
+    name: attr
+  - project: certifi
+    name: certifi
+  - project: chardet
+    name: chardet
+  - project: colorama
+    name: colorama
+  - project: dns
+    name: dns
+  - project: ecdsa
+    name: ecdsa
+  - project: idna
+    name: idna
+  - project: idna_ssl
+    name: idna_ssl
+  - project: jsonrpclib
+    name: jsonrpclib
+  - project: multidict
+    name: multidict
+  - project: protobuf
+    name: protobuf
+  - project: pyaes
+    name: pyaes
+  - project: qdarkstyle
+    name: qdarkstyle
+  - project: qrcode
+    name: qrcode
+  - project: six
+    name: six
+  - project: typing_extensions
+    name: typing_extensions
+  - project: yarl
+    name: yarl

--- a/projects/idna/build
+++ b/projects/idna/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/[% project %]-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+cp -a /var/tmp/build/sdist/[% project %]/[% project %]*/[% project %] ./[% project %]
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/idna/config
+++ b/projects/idna/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 2.8
+git_url: https://github.com/kjd/idna.git
+git_hash: 1cdf175e259b299be76f49c3ddc8794214f9931f
+# TODO: This Git repo doesn't use GPG sigs.  We should pester them about that.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/idna_ssl/build
+++ b/projects/idna_ssl/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/idna-ssl-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+cp -a /var/tmp/build/sdist/[% project %]/idna-ssl*/[% project %].py ./[% project %].py
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/idna_ssl/config
+++ b/projects/idna_ssl/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 1.1.0
+git_url: https://github.com/aio-libs/idna-ssl.git
+git_hash: 1ab8304810f8bd9a880c0a013276cddd3c6e9551
+# TODO: This Git repo uses GPG sigs; we should switch from commit hash to GPG verification.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/jsonrpclib/build
+++ b/projects/jsonrpclib/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/jsonrpclib-pelix-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+cp -a /var/tmp/build/sdist/[% project %]/jsonrpclib-pelix*/[% project %] ./[% project %]
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/jsonrpclib/config
+++ b/projects/jsonrpclib/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 0.4.0
+git_url: https://github.com/tcalmant/jsonrpclib.git
+git_hash: fe9fcf2c99973507f7055d6c9e05e155957c2549
+# TODO: This Git repo doesn't use GPG sigs.  We should pester them about that.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/multidict/build
+++ b/projects/multidict/build
@@ -1,0 +1,22 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/[% project %]-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+mkdir ./[% project %]
+cp -a /var/tmp/build/sdist/[% project %]/[% project %]*/[% project %]/*.py ./[% project %]/
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/multidict/config
+++ b/projects/multidict/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 4.5.2
+git_url: https://github.com/aio-libs/multidict.git
+git_hash: bd40998bf220820a7d636d5f02912c8d4abcac23
+# TODO: This Git repo doesn't use GPG sigs.  We should pester them about that.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/protobuf/build
+++ b/projects/protobuf/build
@@ -1,0 +1,42 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+[% pc('gcc', 'var/setup', { compiler_tarfile => c('input_files_by_name/gcc') }) %]
+
+shopt -s globstar
+
+mkdir -p [% dest_dir _ '/' _ c('filename') %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/protoc/
+cd [% project %]-[% c('version') %]
+./autogen.sh
+./configure --prefix=/var/tmp/dist/protoc/
+make
+make install
+export PATH=/var/tmp/dist/protoc/bin:$PATH
+
+cd python
+
+python3 setup.py build
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/[% project %]-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]/google
+cd /var/tmp/build/sdist/[% project %]/[% project %]*/google
+cp --parents **/*.py /var/tmp/dist/[% project %]/google/
+
+cd /var/tmp/dist/[% project %]
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename') _ '/python-protobuf.tar.gz',
+        }) %]
+
+cd /var/tmp/dist/protoc
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename') _ '/protoc.tar.gz',
+        }) %]

--- a/projects/protobuf/config
+++ b/projects/protobuf/config
@@ -1,0 +1,22 @@
+# vim: filetype=yaml sw=2
+version: 3.8.0
+git_url: https://github.com/protocolbuffers/protobuf.git
+git_hash: 09745575a923640154bcf307fba8aedff47f240a
+# TODO: This Git repo uses GPG sigs; we should switch from commit hash to GPG verification.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %]"
+var:
+  container:
+    use_container: 1
+  deps:
+    - build-essential
+    - automake
+    - autoconf
+    - libtool
+    - zlib1g-dev
+    - hardening-wrapper
+input_files:
+  - project: container-image
+  - project: python
+    name: python
+  - project: gcc
+    name: gcc

--- a/projects/pyaes/build
+++ b/projects/pyaes/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/[% project %]-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+cp -a /var/tmp/build/sdist/[% project %]/[% project %]*/[% project %] ./[% project %]
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/pyaes/config
+++ b/projects/pyaes/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 1.6.1
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python
+  - URL: https://files.pythonhosted.org/packages/source/p/pyaes/pyaes-[% c("version") %].tar.gz
+    sha256sum: 02c1b1405c38d3c370b085fb952dd8bea3fadcee6411ad99f312cc129c536d8f
+    # TODO: This version doesn't show up as a Git tag; where did it come from?

--- a/projects/python
+++ b/projects/python
@@ -1,0 +1,1 @@
+../tor-browser-build/projects/python

--- a/projects/qdarkstyle/build
+++ b/projects/qdarkstyle/build
@@ -1,0 +1,22 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/QDarkStyle-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+mkdir ./[% project %]
+cp -a /var/tmp/build/sdist/[% project %]/QDarkStyle*/[% project %]/*.py ./[% project %]/
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/qdarkstyle/config
+++ b/projects/qdarkstyle/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 2.6.8
+git_url: https://github.com/ColinDuquesnoy/QDarkStyleSheet.git
+git_hash: dbdcd6410d942701cf491033e7ffbbe1b4d8cb1d
+# TODO: This Git repo doesn't use GPG sigs.  We should pester them about that.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/qrcode/build
+++ b/projects/qrcode/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/[% project %]-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+cp -a /var/tmp/build/sdist/[% project %]/[% project %]*/[% project %] ./[% project %]
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/qrcode/config
+++ b/projects/qrcode/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 6.1
+git_url: https://github.com/lincolnloop/python-qrcode.git
+git_hash: d213e0274410312d9741bb84f93220d65d96e27d
+# TODO: This Git repo doesn't use GPG sigs.  We should pester them about that.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/six/build
+++ b/projects/six/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/[% project %]-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+cp -a /var/tmp/build/sdist/[% project %]/[% project %]*/[% project %].py ./[% project %].py
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/six/config
+++ b/projects/six/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 1.12.0
+git_url: https://github.com/benjaminp/six.git
+git_hash: d927b9e27617abca8dbf4d66cc9265ebbde261d6
+# TODO: This Git repo doesn't use GPG sigs.  We should pester them about that.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/typing_extensions/build
+++ b/projects/typing_extensions/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]/typing_extensions
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/[% project %]*.tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+cp -a /var/tmp/build/sdist/[% project %]/[% project %]*/src_py3/[% project %].py ./[% project %].py
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/typing_extensions/config
+++ b/projects/typing_extensions/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 3.7.4
+git_url: https://github.com/python/typing.git
+git_hash: baf63c5924a2b9695175df5d47ced40596024b78
+# TODO: This Git repo uses GPG sigs; we should switch from commit hash to GPG verification.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python

--- a/projects/yarl/build
+++ b/projects/yarl/build
@@ -1,0 +1,22 @@
+#!/bin/bash
+[% c("var/set_default_env") -%]
+[% pc('python', 'var/setup', { python_tarfile => c('input_files_by_name/python') }) %]
+
+tar xvf [% project %]-[% c('version') %].tar.gz
+cd [% project %]-[% c('version') %]
+
+python3 setup.py sdist --format=gztar
+
+mkdir -p /var/tmp/build/sdist/[% project %]
+tar -C /var/tmp/build/sdist/[% project %] -xvf dist/[% project %]-[% c('version') %].tar.gz
+
+mkdir -p /var/tmp/dist/[% project %]
+cd /var/tmp/dist/[% project %]
+
+mkdir ./[% project %]
+cp -a /var/tmp/build/sdist/[% project %]/[% project %]*/[% project %]/*.py ./[% project %]/
+
+[% c('tar', {
+        tar_src => '.',
+        tar_args => '-czf ' _ dest_dir _ '/' _ c('filename'),
+        }) %]

--- a/projects/yarl/config
+++ b/projects/yarl/config
@@ -1,0 +1,13 @@
+# vim: filetype=yaml sw=2
+version: 1.3.0
+git_url: https://github.com/aio-libs/yarl.git
+git_hash: 619cc2203b8888fb9ad552c4a3da6f8b31d1fbac
+# TODO: This Git repo doesn't use GPG sigs.  We should pester them about that.
+filename: "[% project %]-[% c('version') %]-[% c('var/build_id') %].tar.gz"
+var:
+  container:
+    use_container: 1
+input_files:
+  - project: container-image
+  - project: python
+    name: python


### PR DESCRIPTION
This PR modifies the electrum-nmc project to build from Git source instead of the tarball release.

Fixes https://github.com/namecoin/ncdns-repro/issues/31
