### PR TITLE
dnssec-hsts-native: Add JSON manifest to output

### DIFF
--- a/projects/dnssec-hsts-native/build
+++ b/projects/dnssec-hsts-native/build
@@ -38,6 +38,10 @@ ls $GOPATHBIN
 
 cp -a $GOPATHBIN/dnssec_hsts[% IF c("var/windows") %].exe[% END %] $distdir/
 
+# TODO: This JSON file is only tested on GNU/Linux, and definitely won't work
+# on Windows because the "path" field is wrong for Windows.
+cp -a $GOPATH/src/github.com/namecoin/dnssec-hsts-native/setup/org.namecoin.dnssec_hsts.json $distdir/
+
 cd $distdir
 [% c('tar', {
      tar_src   => [ '.' ],

--- a/projects/dnssec-hsts-native/config
+++ b/projects/dnssec-hsts-native/config
@@ -1,6 +1,6 @@
 version: '[% c("abbrev") %]'
 git_url:  https://github.com/namecoin/dnssec-hsts-native.git
-git_hash: '70cc6b40311abe70ab12a71303f69ff027dcf0f4'
+git_hash: 'b1e78c890146cd9a58bec8defd684be443a946da'
 filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
 
 var:


### PR DESCRIPTION
The JSON manifest file is needed in order to use dnssec-hsts-native with Firefox; not sure why I forgot to add it here originally.