### PR TITLE
Makefile: also build the non-ncdns projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ rbm=./rbm/rbm
 
 all: release
 
-release: submodule-update
-	$(rbm) build ncdns --target release --target ncdns-all
+# TODO: Replace the Makefile-based metatarget with an rbm-based one.
+release: submodule-update release-linux-x86_64 release-linux-i686 release-windows-x86_64 release-windows-i686 release-osx-x86_64
+	#$(rbm) build ncdns --target release --target ncdns-all
 
 release-android-armv7: submodule-update
 	$(rbm) build ncdns --target release --target ncdns-android-armv7
@@ -12,19 +13,44 @@ release-android-x86: submodule-update
 	$(rbm) build ncdns --target release --target ncdns-android-x86
 
 release-linux-x86_64: submodule-update
+	$(rbm) build certdehydrate-dane-rest-api --target release --target ncdns-linux-x86_64
+	$(rbm) build dnssec-hsts --target release --target ncdns-linux-x86_64
+	$(rbm) build dnssec-hsts-native --target release --target ncdns-linux-x86_64
 	$(rbm) build ncdns --target release --target ncdns-linux-x86_64
+	$(rbm) build ncp11 --target release --target ncdns-linux-x86_64
+	$(rbm) build ncprop279 --target release --target ncdns-linux-x86_64
 
 release-linux-i686: submodule-update
+	$(rbm) build certdehydrate-dane-rest-api --target release --target ncdns-linux-i686
+	$(rbm) build dnssec-hsts --target release --target ncdns-linux-i686
+	$(rbm) build dnssec-hsts-native --target release --target ncdns-linux-i686
 	$(rbm) build ncdns --target release --target ncdns-linux-i686
+	$(rbm) build ncp11 --target release --target ncdns-linux-i686
+	$(rbm) build ncprop279 --target release --target ncdns-linux-i686
 
 release-windows-i686: submodule-update
+	$(rbm) build certdehydrate-dane-rest-api --target release --target ncdns-windows-i686
+	$(rbm) build dnssec-hsts --target release --target ncdns-windows-i686
+	$(rbm) build dnssec-hsts-native --target release --target ncdns-windows-i686
 	$(rbm) build ncdns --target release --target ncdns-windows-i686
+	$(rbm) build ncp11 --target release --target ncdns-windows-i686
+	$(rbm) build ncprop279 --target release --target ncdns-windows-i686
 
 release-windows-x86_64: submodule-update
+	$(rbm) build certdehydrate-dane-rest-api --target release --target ncdns-windows-x86_64
+	$(rbm) build dnssec-hsts --target release --target ncdns-windows-x86_64
+	$(rbm) build dnssec-hsts-native --target release --target ncdns-windows-x86_64
 	$(rbm) build ncdns --target release --target ncdns-windows-x86_64
+	$(rbm) build ncp11 --target release --target ncdns-windows-x86_64
+	$(rbm) build ncprop279 --target release --target ncdns-windows-x86_64
 
 release-osx-x86_64: submodule-update
+	$(rbm) build certdehydrate-dane-rest-api --target release --target ncdns-osx-x86_64
+	$(rbm) build dnssec-hsts --target release --target ncdns-osx-x86_64
+	$(rbm) build dnssec-hsts-native --target release --target ncdns-osx-x86_64
 	$(rbm) build ncdns --target release --target ncdns-osx-x86_64
+	$(rbm) build ncp11 --target release --target ncdns-osx-x86_64
+	$(rbm) build ncprop279 --target release --target ncdns-osx-x86_64
 
 submodule-update:
 	git submodule update --init


### PR DESCRIPTION
This is a temporary kludge until we port over Tor's `release` project.