### PR TITLE
Bump ncdns version (use-ca in generate_nmc_cert)

### DIFF
--- a/projects/github.com,namecoin,x509-signature-splice/config
+++ b/projects/github.com,namecoin,x509-signature-splice/config
@@ -1,0 +1,22 @@
+version: '[% c("abbrev") %]'
+git_url:  https://github.com/namecoin/x509-signature-splice.git
+# go1.11 branch
+git_hash: 'c3ef8e04f5bd6315a4a9476964df6c410700913a'
+filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
+
+build: '[% c("projects/go/var/build_go_lib") %]'
+
+var:
+  container:
+    use_container: 1
+  go_lib: github.com/namecoin/x509-signature-splice
+  go_lib_install:
+    - github.com/namecoin/x509-signature-splice/x509
+  build_go_lib_pre: |
+    export CGO_ENABLED=0
+    go generate github.com/namecoin/x509-signature-splice/x509
+
+input_files:
+  - project: container-image
+  - name: go
+    project: go

--- a/projects/ncdns/build
+++ b/projects/ncdns/build
@@ -29,7 +29,6 @@ mkdir -p $GOPATH/src/github.com/namecoin
 tar -C $GOPATH/src/github.com/namecoin -xf [% project %]-[% c('version') %].tar.gz
 mv $GOPATH/src/github.com/namecoin/ncdns-[% c('version') %] $GOPATH/src/github.com/namecoin/ncdns
 
-go generate github.com/namecoin/ncdns/x509
 go install -ldflags '-s' github.com/namecoin/ncdns/...
 
 #mkdir -p /var/tmp/build

--- a/projects/ncdns/config
+++ b/projects/ncdns/config
@@ -3,7 +3,7 @@ git_url: https://github.com/namecoin/ncdns.git
 # Using latest master branch because we need the RPC timeout feature.  Once
 # it's in a tagged release, we'll go back to using a version tag here.
 #git_hash: 'v[% c("version") %]'
-git_hash: '4ea036742bd5b10a7b56765355dcc88724632f32'
+git_hash: '006f537e01cf20db01b18e399ed51f57211db91c'
 filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
 
 var:
@@ -18,6 +18,7 @@ var:
     - github.com,kr,pretty
     - github.com,miekg,dns
     - github.com,namecoin,tlsrestrictnss
+    - github.com,namecoin,x509-signature-splice
     - gopkg.in,hlandau,madns.v1
     - gopkg.in,hlandau,easyconfig.v1
     - gopkg.in,hlandau,service.v2
@@ -49,7 +50,7 @@ targets:
         - github.com,hlandauf,btcjson
         - github.com,kr,pretty
         - github.com,miekg,dns
-        - github.com,namecoin,tlsrestrictnss
+        - github.com,namecoin,x509-signature-splice
         - gopkg.in,hlandau,madns.v1
         - gopkg.in,hlandau,easyconfig.v1
         - gopkg.in,hlandau,service.v2
@@ -85,6 +86,8 @@ input_files:
     project: github.com,miekg,dns
   - name: github.com,namecoin,tlsrestrictnss
     project: github.com,namecoin,tlsrestrictnss
+  - name: github.com,namecoin,x509-signature-splice
+    project: github.com,namecoin,x509-signature-splice
   - name: gopkg.in,hlandau,madns.v1
     project: gopkg.in,hlandau,madns.v1
   - name: github.com,kr,pretty


### PR DESCRIPTION
This PR bumps the version of ncdns to add support for name-constrained CA's in `generate_nmc_cert`.