### PR TITLE
Set project versions for ncdns 0.0.9

### DIFF
--- a/projects/certdehydrate-dane-rest-api/config
+++ b/projects/certdehydrate-dane-rest-api/config
@@ -1,4 +1,4 @@
-version: '[% c("abbrev") %]'
+version: '0.0.1'
 git_url:  https://github.com/namecoin/certdehydrate-dane-rest-api.git
 git_hash: '2eeb272f4bb7dffc13e39a609b308656a5a121ea'
 filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'

--- a/projects/dnssec-hsts-native/config
+++ b/projects/dnssec-hsts-native/config
@@ -1,4 +1,4 @@
-version: '[% c("abbrev") %]'
+version: '0.0.1'
 git_url:  https://github.com/namecoin/dnssec-hsts-native.git
 git_hash: 'b1e78c890146cd9a58bec8defd684be443a946da'
 filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'

--- a/projects/dnssec-hsts/config
+++ b/projects/dnssec-hsts/config
@@ -1,5 +1,5 @@
 # vim: filetype=yaml sw=2
-version: '[% c("abbrev") %]'
+version: '0.0.1'
 git_url:  https://github.com/namecoin/dnssec-hsts.git
 git_hash: 'e24019949a8344d672591d1676a5c9ab67853fa4'
 filename: '[% project %]-[% c("version") %]-[% c("var/build_id") %].xpi'

--- a/projects/github.com,namecoin,crosssign/config
+++ b/projects/github.com,namecoin,crosssign/config
@@ -1,4 +1,4 @@
-version: '[% c("abbrev") %]'
+version: '0.0.4'
 git_url:  https://github.com/namecoin/crosssign.git
 git_hash: '44408047169ecb5b56346855e0bc931a06872eb0'
 filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'

--- a/projects/github.com,namecoin,crosssignnameconstraint/config
+++ b/projects/github.com,namecoin,crosssignnameconstraint/config
@@ -1,4 +1,4 @@
-version: '[% c("abbrev") %]'
+version: '0.0.3'
 git_url:  https://github.com/namecoin/crosssignnameconstraint.git
 git_hash: '76052b08844e6b81678430656c5fc9f79a49f795'
 filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'

--- a/projects/github.com,namecoin,pkcs11mod/config
+++ b/projects/github.com,namecoin,pkcs11mod/config
@@ -1,4 +1,4 @@
-version: '[% c("abbrev") %]'
+version: '0.0.1'
 git_url:  https://github.com/namecoin/pkcs11mod.git
 git_hash: '[% config.var_p.id.${"github.com/namecoin/pkcs11mod"} %]'
 filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'

--- a/projects/github.com,namecoin,qlib/config
+++ b/projects/github.com,namecoin,qlib/config
@@ -1,4 +1,4 @@
-version: '[% c("abbrev") %]'
+version: '0.0.1'
 git_url:  https://github.com/namecoin/qlib.git
 git_hash: '99c375238fe562c99a2c691c433a28f90fd15afe'
 filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'

--- a/projects/github.com,namecoin,safetlsa/config
+++ b/projects/github.com,namecoin,safetlsa/config
@@ -1,4 +1,4 @@
-version: '[% c("abbrev") %]'
+version: '0.0.1'
 git_url:  https://github.com/namecoin/safetlsa.git
 git_hash: '818ee2aef753c7f761cd26fbc5e4fde015f66b70'
 filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'

--- a/projects/github.com,namecoin,tlsrestrictnss/config
+++ b/projects/github.com,namecoin,tlsrestrictnss/config
@@ -1,4 +1,4 @@
-version: '[% c("abbrev") %]'
+version: '0.0.3'
 git_url:  https://github.com/namecoin/tlsrestrictnss.git
 git_hash: '01a37997e55de687f4b5228e0e9315a6d698bd2a'
 filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'

--- a/projects/ncdns/config
+++ b/projects/ncdns/config
@@ -1,4 +1,4 @@
-#version: 0.0.8
+version: 0.0.9
 git_url: https://github.com/namecoin/ncdns.git
 # Using latest master branch because we need the RPC timeout feature.  Once
 # it's in a tagged release, we'll go back to using a version tag here.

--- a/projects/ncp11/config
+++ b/projects/ncp11/config
@@ -1,4 +1,4 @@
-version: '[% c("abbrev") %]'
+version: '0.0.1'
 git_url: https://github.com/namecoin/ncp11.git
 git_hash: 7fbf1057d7053d9fb72f72ea795ca8bb36672552
 filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'

--- a/projects/ncprop279/config
+++ b/projects/ncprop279/config
@@ -1,4 +1,4 @@
-version: '[% c("abbrev") %]'
+version: '0.0.1'
 git_url:  https://github.com/namecoin/ncprop279.git
 git_hash: 'd72977987d841fa0b7fa51108a868263e7f4a9a0'
 filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'


### PR DESCRIPTION
This is expected to be the last PR prior to the ncdns-repro v0.0.9 tag.