### PR TITLE
Fix miekg/dns v1.1.16

### DIFF
--- a/keyring/clang.gpg
+++ b/keyring/clang.gpg
@@ -1,0 +1,1 @@
+../tor-browser-build/keyring/clang.gpg

--- a/projects/clang
+++ b/projects/clang
@@ -1,0 +1,1 @@
+../tor-browser-build/projects/clang

--- a/projects/github.com,miekg,dns/config
+++ b/projects/github.com,miekg,dns/config
@@ -9,9 +9,26 @@ var:
   container:
     use_container: 1
   go_lib: github.com/miekg/dns
-  go_lib_deps: []
+  go_lib_deps:
+    - golang.org,x,crypto,ed25519
+    - golang.org,x,net,ip
+    - golang.org,x,sys,unix
+
+targets:
+  windows:
+    var:
+      go_lib_deps:
+        - golang.org,x,crypto,ed25519
 
 input_files:
   - project: container-image
   - name: go
     project: go
+  - name: golang.org,x,crypto,ed25519
+    project: golang.org,x,crypto,ed25519
+  - name: golang.org,x,net,ip
+    project: golang.org,x,net,ip
+    enable: '[% ! c("var/windows") %]'
+  - name: golang.org,x,sys,unix
+    project: golang.org,x,sys,unix
+    enable: '[% ! c("var/windows") %]'

--- a/projects/golang.org,x,crypto
+++ b/projects/golang.org,x,crypto
@@ -1,0 +1,1 @@
+../tor-browser-build/projects/goxcrypto

--- a/projects/golang.org,x,crypto,ed25519/config
+++ b/projects/golang.org,x,crypto,ed25519/config
@@ -1,0 +1,19 @@
+# vim: filetype=yaml sw=2
+version: '[% c("abbrev") %]'
+git_url: '[% pc("golang.org,x,crypto", "git_url") %]'
+git_hash: '[% pc("golang.org,x,crypto", "git_hash") %]'
+filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
+
+build: '[% c("projects/go/var/build_go_lib") %]'
+
+var:
+  container:
+    use_container: 1
+  go_lib: golang.org/x/crypto
+  go_lib_install:
+    - golang.org/x/crypto/ed25519
+
+input_files:
+  - project: container-image
+  - name: go
+    project: go

--- a/projects/golang.org,x,net,ip/config
+++ b/projects/golang.org,x,net,ip/config
@@ -1,0 +1,20 @@
+# vim: filetype=yaml sw=2
+version: '[% c("abbrev") %]'
+git_url: '[% pc("golang.org,x,net", "git_url") %]'
+git_hash: '[% pc("golang.org,x,net", "git_hash") %]'
+filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
+
+build: '[% c("projects/go/var/build_go_lib") %]'
+
+var:
+  container:
+    use_container: 1
+  go_lib: golang.org/x/net
+  go_lib_install:
+    - golang.org/x/net/ipv4
+    - golang.org/x/net/ipv6
+
+input_files:
+  - project: container-image
+  - name: go
+    project: go

--- a/projects/golang.org,x,sys,unix/config
+++ b/projects/golang.org,x,sys,unix/config
@@ -1,0 +1,19 @@
+# vim: filetype=yaml sw=2
+version: '[% c("abbrev") %]'
+git_url: '[% pc("golang.org,x,sys", "git_url") %]'
+git_hash: '[% pc("golang.org,x,sys", "git_hash") %]'
+filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
+
+build: '[% c("projects/go/var/build_go_lib") %]'
+
+var:
+  container:
+    use_container: 1
+  go_lib: golang.org/x/sys
+  go_lib_install:
+    - golang.org/x/sys/unix
+
+input_files:
+  - project: container-image
+  - name: go
+    project: go


### PR DESCRIPTION
This PR fixes various build errors affecting miekg/dns v1.1.16 (introduced by the upstream dependency bump in https://github.com/namecoin/ncdns-repro/pull/54 ).