### PR TITLE
ncdns: Support disabling TLSA

### DIFF
--- a/projects/ncdns/build
+++ b/projects/ncdns/build
@@ -25,6 +25,14 @@ mkdir -p $distdir
   tar -C /var/tmp/dist -xf [% c('input_files_by_name/' _ dep) %]
 [% END -%]
 
+[% FOREACH dep = c("var/os_go_lib_deps") -%]
+  tar -C /var/tmp/dist -xf [% c('input_files_by_name/' _ dep) %]
+[% END -%]
+
+[% FOREACH dep = c("var/optional_go_lib_deps") -%]
+  tar -C /var/tmp/dist -xf [% c('input_files_by_name/' _ dep) %]
+[% END -%]
+
 mkdir -p $GOPATH/src/github.com/namecoin
 tar -C $GOPATH/src/github.com/namecoin -xf [% project %]-[% c('version') %].tar.gz
 mv $GOPATH/src/github.com/namecoin/ncdns-[% c('version') %] $GOPATH/src/github.com/namecoin/ncdns
@@ -35,7 +43,13 @@ mv $GOPATH/src/github.com/namecoin/ncdns-[% c('version') %] $GOPATH/src/github.c
   TAGS="-tags no_namecoin_tls"
 [% END %]
 
-go install $TAGS -ldflags '-s' github.com/namecoin/ncdns/...
+[% FOREACH inst IN c("var/go_lib_install") %]
+  go install $TAGS -ldflags '-s' [% inst %]
+[% END %]
+
+[% FOREACH inst IN c("var/optional_go_lib_install") %]
+  go install $TAGS -ldflags '-s' [% inst %]
+[% END %]
 
 #mkdir -p /var/tmp/build
 #tar -C /var/tmp/build -xf [% project %]-[% c('version') %].tar.gz
@@ -67,9 +81,15 @@ cd /var/tmp/dist
   # Build as executable
   ls $GOPATHBIN
 
-  for x in ncdns ncdumpzone ncdt generate_nmc_cert tlsrestrict_chromium_tool; do
+  for x in ncdns ncdt; do
     cp -a $GOPATHBIN/"$x"[% IF c("var/windows") %].exe[% END %] $distdir/
   done
+
+  [% IF c("var/enable_namecoin_tlsa") %]
+    for x in ncdumpzone generate_nmc_cert tlsrestrict_chromium_tool; do
+      cp -a $GOPATHBIN/"$x"[% IF c("var/windows") %].exe[% END %] $distdir/
+    done
+  [% END %]
 
   cd $distdir
   [% c('tar', {

--- a/projects/ncdns/build
+++ b/projects/ncdns/build
@@ -29,7 +29,13 @@ mkdir -p $GOPATH/src/github.com/namecoin
 tar -C $GOPATH/src/github.com/namecoin -xf [% project %]-[% c('version') %].tar.gz
 mv $GOPATH/src/github.com/namecoin/ncdns-[% c('version') %] $GOPATH/src/github.com/namecoin/ncdns
 
-go install -ldflags '-s' github.com/namecoin/ncdns/...
+[% IF c("var/enable_namecoin_tlsa") %]
+  TAGS=""
+[% ELSE %]
+  TAGS="-tags no_namecoin_tls"
+[% END %]
+
+go install $TAGS -ldflags '-s' github.com/namecoin/ncdns/...
 
 #mkdir -p /var/tmp/build
 #tar -C /var/tmp/build -xf [% project %]-[% c('version') %].tar.gz

--- a/projects/ncdns/config
+++ b/projects/ncdns/config
@@ -21,14 +21,37 @@ var:
     - gobtcjson
     - gopretty
     - godns
-    - gotlsrestrictnss
-    - gox509signaturesplice
     - gomadns
     - goeasyconfig
     - goservice
     - goxnet
+  go_lib_install:
+    - github.com/namecoin/ncdns
+    - github.com/namecoin/ncdns/backend
+    - github.com/namecoin/ncdns/namecoin
+    - github.com/namecoin/ncdns/ncdomain
+    - github.com/namecoin/ncdns/ncdt
+    - github.com/namecoin/ncdns/rrtourl
+    - github.com/namecoin/ncdns/server
+    - github.com/namecoin/ncdns/testutil
+    - github.com/namecoin/ncdns/tlshook
+    - github.com/namecoin/ncdns/util
   go_lib_no_output: 1
   enable_namecoin_tlsa: 1
+  os_go_lib_deps: []
+  optional_go_lib_deps:
+    - gotlsrestrictnss
+    - gox509signaturesplice
+  optional_go_lib_install:
+    - github.com/namecoin/ncdns/certdehydrate
+    - github.com/namecoin/ncdns/certinject
+    - github.com/namecoin/ncdns/generate_nmc_cert
+    - github.com/namecoin/ncdns/ncdumpzone
+    - github.com/namecoin/ncdns/ncdumpzone/ncdumpzone
+    - github.com/namecoin/ncdns/tlsoverridefirefox
+    - github.com/namecoin/ncdns/tlsoverridefirefoxsync
+    - github.com/namecoin/ncdns/tlsrestrictchromium
+    - github.com/namecoin/ncdns/tlsrestrict_chromium_tool
 
 targets:
   linux:
@@ -47,25 +70,14 @@ targets:
       cgo: 0
   windows:
     var:
-      go_lib_deps:
-        - gogroupcache
-        - godegoutils
-        - godexlogconfig
-        - goncbtcjsontypes
-        - gobtcjson
-        - gopretty
-        - godns
-        - gotlsrestrictnss
-        - gox509signaturesplice
-        - gomadns
-        - goeasyconfig
-        - goservice
-        - goxnet
+      os_go_lib_deps:
         - goxsys
       cgo: 0
   disable_namecoin_tlsa:
     var:
       enable_namecoin_tlsa: 0
+      optional_go_lib_deps: []
+      optional_go_lib_install: []
 
 input_files:
   - project: container-image
@@ -95,8 +107,10 @@ input_files:
     project: godns
   - name: gotlsrestrictnss
     project: gotlsrestrictnss
+    enable: '[% c("var/enable_namecoin_tlsa") %]'
   - name: gox509signaturesplice
     project: gox509signaturesplice
+    enable: '[% c("var/enable_namecoin_tlsa") %]'
   - name: gomadns
     project: gomadns
   - name: gopretty

--- a/projects/ncdns/config
+++ b/projects/ncdns/config
@@ -1,11 +1,12 @@
 #version: 0.0.9
-# Using latest master branch because we need the stream isolation feature.
-# Once it's in a tagged release, we'll go back to using a version number here.
+# Using latest master branch because we need the stream isolation and
+# disable_namecoin_tlsa features.  Once they're in a tagged release, we'll go
+# back to using a version number here.
 version: '[% c("abbrev") %]'
 git_url: https://github.com/namecoin/ncdns.git
-# Using latest master branch because we need the stream isolation feature.
-# Once it's in a tagged release, we'll go back to using a hash that corresponds
-# to a tag here.
+# Using latest master branch because we need the stream isolation and
+# disable_namecoin_tlsa features.  Once they're in a tagged release, we'll go
+# back to using a hash that corresponds to a tag here.
 git_hash: '1e2eea58c79686eea47de873580bcd907ca67d80'
 filename: '[% project %]-[% c("version") %]-[% c("var/osname") %]-[% c("var/build_id") %].tar.gz'
 
@@ -27,6 +28,7 @@ var:
     - goservice
     - goxnet
   go_lib_no_output: 1
+  enable_namecoin_tlsa: 1
 
 targets:
   linux:
@@ -61,6 +63,9 @@ targets:
         - goxnet
         - goxsys
       cgo: 0
+  disable_namecoin_tlsa:
+    var:
+      enable_namecoin_tlsa: 0
 
 input_files:
   - project: container-image

--- a/projects/ncprop279/build
+++ b/projects/ncprop279/build
@@ -13,7 +13,13 @@ mkdir -p $GOPATH/src/github.com/namecoin
 tar -C $GOPATH/src/github.com/namecoin -xf [% project %]-[% c('version') %].tar.gz
 mv $GOPATH/src/github.com/namecoin/ncprop279-[% c('version') %] $GOPATH/src/github.com/namecoin/ncprop279
 
-go install -ldflags '-s' github.com/namecoin/ncprop279
+[% IF c("var/enable_namecoin_tlsa") %]
+  TAGS=""
+[% ELSE %]
+  TAGS="-tags no_namecoin_tls"
+[% END %]
+
+go install $TAGS -ldflags '-s' github.com/namecoin/ncprop279
 
 #mkdir -p /var/tmp/build
 #tar -C /var/tmp/build -xf [% project %]-[% c('version') %].tar.gz

--- a/projects/ncprop279/config
+++ b/projects/ncprop279/config
@@ -20,6 +20,12 @@ var:
   cgo: 0
   build_go_lib_pre: |
     export CGO_ENABLED=[% c("var/cgo") %] 
+  enable_namecoin_tlsa: 1
+
+targets:
+  disable_namecoin_tlsa:
+    var:
+      enable_namecoin_tlsa: 0
 
 input_files:
   - project: container-image


### PR DESCRIPTION
This PR exposes https://github.com/namecoin/ncdns/pull/115 as an rbm target.

TODO:

- [x] Reduce dependencies accordingly.