### PR TITLE
Use parent tor-browser-build instead of submodule if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,7 @@ release-osx-x86_64: submodule-update
 	$(rbm) build ncprop279 --target release --target ncdns-osx-x86_64
 
 submodule-update:
-	git submodule update --init
-	$(MAKE) -C tor-browser-build submodule-update
+	./setup-submodule-symlinks
 
 fetch: submodule-update
 	$(rbm) fetch

--- a/setup-submodule-symlinks
+++ b/setup-submodule-symlinks
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# This script inits tor-browser-build as a Git submodule of ncdns-repro, unless
+# ncdns-repro is inside a tor-browser-build tree (e.g. as a Git submodule of
+# tor-browser-build), in which case it uses the parent tor-browser-build.
+
+set -euo pipefail
+shopt -s nullglob globstar
+
+ncdnsdir=$(pwd)
+parentdir=$(dirname "${ncdnsdir}")
+parentbase=$(basename "${parentdir}")
+
+if [ "${parentbase}" == "tor-browser-build" ]; then
+  if [ -e tor-browser-build ]; then
+    rm tor-browser-build || rmdir tor-browser-build || mv tor-browser-build tor-browser-build-backup
+  fi
+  ln -s -T .. tor-browser-build
+else
+  git submodule update --init
+  make -C tor-browser-build submodule-update
+fi


### PR DESCRIPTION
TODO:

- [ ] Redirect error messages from rm/rmdir to `/dev/null`.  (Split out into separate issue; not a blocker.)