### PR TITLE
Set static build ID in Go linker flags

### DIFF
--- a/projects/certdehydrate-dane-rest-api/build
+++ b/projects/certdehydrate-dane-rest-api/build
@@ -13,7 +13,8 @@ mkdir -p $GOPATH/src/github.com/namecoin
 tar -C $GOPATH/src/github.com/namecoin -xf [% project %]-[% c('version') %].tar.gz
 mv $GOPATH/src/github.com/namecoin/certdehydrate-dane-rest-api-[% c('version') %] $GOPATH/src/github.com/namecoin/certdehydrate-dane-rest-api
 
-go install -ldflags '-s' github.com/namecoin/certdehydrate-dane-rest-api
+# TODO: Remove static build ID after migrating to Go 1.13.3+
+go install -ldflags '-s -buildid=' github.com/namecoin/certdehydrate-dane-rest-api
 
 #mkdir -p /var/tmp/build
 #tar -C /var/tmp/build -xf [% project %]-[% c('version') %].tar.gz

--- a/projects/dnssec-hsts-native/build
+++ b/projects/dnssec-hsts-native/build
@@ -13,7 +13,8 @@ mkdir -p $GOPATH/src/github.com/namecoin
 tar -C $GOPATH/src/github.com/namecoin -xf [% project %]-[% c('version') %].tar.gz
 mv $GOPATH/src/github.com/namecoin/dnssec-hsts-native-[% c('version') %] $GOPATH/src/github.com/namecoin/dnssec-hsts-native
 
-go install -ldflags '-s' github.com/namecoin/dnssec-hsts-native/src/dnssec_hsts
+# TODO: Remove static build ID after migrating to Go 1.13.3+
+go install -ldflags '-s -buildid=' github.com/namecoin/dnssec-hsts-native/src/dnssec_hsts
 
 #mkdir -p /var/tmp/build
 #tar -C /var/tmp/build -xf [% project %]-[% c('version') %].tar.gz

--- a/projects/ncdns/build
+++ b/projects/ncdns/build
@@ -44,11 +44,13 @@ mv $GOPATH/src/github.com/namecoin/ncdns-[% c('version') %] $GOPATH/src/github.c
 [% END %]
 
 [% FOREACH inst IN c("var/go_lib_install") %]
-  go install $TAGS -ldflags '-s' [% inst %]
+  # TODO: Remove static build ID after migrating to Go 1.13.3+
+  go install $TAGS -ldflags '-s -buildid=' [% inst %]
 [% END %]
 
 [% FOREACH inst IN c("var/optional_go_lib_install") %]
-  go install $TAGS -ldflags '-s' [% inst %]
+  # TODO: Remove static build ID after migrating to Go 1.13.3+
+  go install $TAGS -ldflags '-s -buildid=' [% inst %]
 [% END %]
 
 #mkdir -p /var/tmp/build

--- a/projects/ncp11/build
+++ b/projects/ncp11/build
@@ -29,7 +29,8 @@ mkdir -p $GOPATH/src/github.com/namecoin
 tar -C $GOPATH/src/github.com/namecoin -xf [% project %]-[% c('version') %].tar.gz
 mv $GOPATH/src/github.com/namecoin/ncp11-[% c('version') %] $GOPATH/src/github.com/namecoin/ncp11
 
-go install -ldflags '-s' -buildmode c-shared github.com/namecoin/ncp11
+# TODO: Remove static build ID after migrating to Go 1.13.3+
+go install -ldflags '-s -buildid=' -buildmode c-shared github.com/namecoin/ncp11
 
 #mkdir -p /var/tmp/build
 #tar -C /var/tmp/build -xf [% project %]-[% c('version') %].tar.gz

--- a/projects/ncprop279/build
+++ b/projects/ncprop279/build
@@ -19,7 +19,8 @@ mv $GOPATH/src/github.com/namecoin/ncprop279-[% c('version') %] $GOPATH/src/gith
   TAGS="-tags no_namecoin_tls"
 [% END %]
 
-go install $TAGS -ldflags '-s' github.com/namecoin/ncprop279
+# TODO: Remove static build ID after migrating to Go 1.13.3+
+go install $TAGS -ldflags '-s -buildid=' github.com/namecoin/ncprop279
 
 #mkdir -p /var/tmp/build
 #tar -C /var/tmp/build -xf [% project %]-[% c('version') %].tar.gz


### PR DESCRIPTION
This improves build reproducibility.

Fixes https://github.com/namecoin/ncdns-repro/issues/57