### PR TITLE
Cirrus: Actually clean old output files

### DIFF
--- a/tools/cirrus_build_project.sh
+++ b/tools/cirrus_build_project.sh
@@ -79,7 +79,7 @@ fi
 echo "Cleaning cache..."
 rm -rfv out/container-image
 if [[ "$SHOULD_BUILD" -eq 0 ]]; then
-    ./tools/clean-old --dry-run
+    ./tools/clean-old
 fi
 
 echo "Splitting caches..."


### PR DESCRIPTION
Don't just do a dry-run.  Should fix the cache overflow that was affecting https://github.com/namecoin/ncdns-repro/pull/89#issuecomment-804303491 .