### PR TITLE
Cirrus: Segregate plain-binaries cache

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,6 +16,13 @@ release_linux_x86_64_download_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -66,6 +73,13 @@ release_linux_x86_64_gcc_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -123,6 +137,13 @@ release_linux_x86_64_gcc_2_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -180,6 +201,13 @@ release_linux_x86_64_goeasyconfig_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -237,6 +265,13 @@ release_linux_x86_64_ncdns_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -294,6 +329,13 @@ release_linux_x86_64_ncp11_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -351,6 +393,13 @@ release_linux_x86_64_ncprop279_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -408,6 +457,13 @@ release_linux_x86_64_plain-binaries_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -465,6 +521,13 @@ release_linux_x86_64_release_nosign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -525,6 +588,13 @@ release_linux_x86_64_release_sign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -587,6 +657,13 @@ release_linux_i686_download_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -637,6 +714,13 @@ release_linux_i686_gcc_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -694,6 +778,13 @@ release_linux_i686_gcc_2_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -751,6 +842,13 @@ release_linux_i686_goeasyconfig_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -808,6 +906,13 @@ release_linux_i686_ncdns_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -865,6 +970,13 @@ release_linux_i686_ncp11_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -922,6 +1034,13 @@ release_linux_i686_ncprop279_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -979,6 +1098,13 @@ release_linux_i686_plain-binaries_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -1036,6 +1162,13 @@ release_linux_i686_release_nosign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -1096,6 +1229,13 @@ release_linux_i686_release_sign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_linux_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -1158,6 +1298,13 @@ release_windows_x86_64_download_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1208,6 +1355,13 @@ release_windows_x86_64_mingw-w64_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1265,6 +1419,13 @@ release_windows_x86_64_mingw-w64_2_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1322,6 +1483,13 @@ release_windows_x86_64_goeasyconfig_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1379,6 +1547,13 @@ release_windows_x86_64_ncdns_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1436,6 +1611,13 @@ release_windows_x86_64_ncp11_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1493,6 +1675,13 @@ release_windows_x86_64_ncprop279_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1550,6 +1739,13 @@ release_windows_x86_64_plain-binaries_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1607,6 +1803,13 @@ release_windows_x86_64_release_nosign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1667,6 +1870,13 @@ release_windows_x86_64_release_sign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1729,6 +1939,13 @@ release_windows_i686_download_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -1779,6 +1996,13 @@ release_windows_i686_mingw-w64_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -1836,6 +2060,13 @@ release_windows_i686_mingw-w64_2_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -1893,6 +2124,13 @@ release_windows_i686_goeasyconfig_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -1950,6 +2188,13 @@ release_windows_i686_ncdns_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2007,6 +2252,13 @@ release_windows_i686_ncp11_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2064,6 +2316,13 @@ release_windows_i686_ncprop279_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2121,6 +2380,13 @@ release_windows_i686_plain-binaries_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2178,6 +2444,13 @@ release_windows_i686_release_nosign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2238,6 +2511,13 @@ release_windows_i686_release_sign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_windows_i686_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2300,6 +2580,13 @@ release_osx_x86_64_download_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_osx_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2350,6 +2637,13 @@ release_osx_x86_64_macosx-toolchain_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_osx_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2407,6 +2701,13 @@ release_osx_x86_64_macosx-toolchain_2_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_osx_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2464,6 +2765,13 @@ release_osx_x86_64_goeasyconfig_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_osx_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2521,6 +2829,13 @@ release_osx_x86_64_ncdns_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_osx_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2578,6 +2893,13 @@ release_osx_x86_64_ncp11_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_osx_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2635,6 +2957,13 @@ release_osx_x86_64_ncprop279_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_osx_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2692,6 +3021,13 @@ release_osx_x86_64_plain-binaries_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_osx_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2749,6 +3085,13 @@ release_osx_x86_64_release_nosign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_osx_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2809,6 +3152,13 @@ release_osx_x86_64_release_sign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache1"
+  out2_release_osx_x86_64_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - "echo out2_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache2"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,6 +23,13 @@ release_linux_x86_64_download_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -80,6 +87,13 @@ release_linux_x86_64_gcc_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -144,6 +158,13 @@ release_linux_x86_64_gcc_2_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -208,6 +229,13 @@ release_linux_x86_64_goeasyconfig_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -272,6 +300,13 @@ release_linux_x86_64_ncdns_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -336,6 +371,13 @@ release_linux_x86_64_ncp11_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -400,6 +442,13 @@ release_linux_x86_64_ncprop279_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -464,6 +513,13 @@ release_linux_x86_64_plain-binaries_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -528,6 +584,13 @@ release_linux_x86_64_release_nosign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -595,6 +658,13 @@ release_linux_x86_64_release_sign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -664,6 +734,13 @@ release_linux_i686_download_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -721,6 +798,13 @@ release_linux_i686_gcc_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -785,6 +869,13 @@ release_linux_i686_gcc_2_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -849,6 +940,13 @@ release_linux_i686_goeasyconfig_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -913,6 +1011,13 @@ release_linux_i686_ncdns_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -977,6 +1082,13 @@ release_linux_i686_ncp11_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -1041,6 +1153,13 @@ release_linux_i686_ncprop279_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -1105,6 +1224,13 @@ release_linux_i686_plain-binaries_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -1169,6 +1295,13 @@ release_linux_i686_release_nosign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -1236,6 +1369,13 @@ release_linux_i686_release_sign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_linux_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_linux_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_linux_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -1305,6 +1445,13 @@ release_windows_x86_64_download_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1362,6 +1509,13 @@ release_windows_x86_64_mingw-w64_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1426,6 +1580,13 @@ release_windows_x86_64_mingw-w64_2_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1490,6 +1651,13 @@ release_windows_x86_64_goeasyconfig_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1554,6 +1722,13 @@ release_windows_x86_64_ncdns_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1618,6 +1793,13 @@ release_windows_x86_64_ncp11_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1682,6 +1864,13 @@ release_windows_x86_64_ncprop279_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1746,6 +1935,13 @@ release_windows_x86_64_plain-binaries_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1810,6 +2006,13 @@ release_windows_x86_64_release_nosign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1877,6 +2080,13 @@ release_windows_x86_64_release_sign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -1946,6 +2156,13 @@ release_windows_i686_download_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2003,6 +2220,13 @@ release_windows_i686_mingw-w64_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2067,6 +2291,13 @@ release_windows_i686_mingw-w64_2_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2131,6 +2362,13 @@ release_windows_i686_goeasyconfig_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2195,6 +2433,13 @@ release_windows_i686_ncdns_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2259,6 +2504,13 @@ release_windows_i686_ncp11_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2323,6 +2575,13 @@ release_windows_i686_ncprop279_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2387,6 +2646,13 @@ release_windows_i686_plain-binaries_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2451,6 +2717,13 @@ release_windows_i686_release_nosign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2518,6 +2791,13 @@ release_windows_i686_release_sign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_windows_i686_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_windows_i686"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_windows_i686_cache:
     folder: git_clones
     fingerprint_script:
@@ -2587,6 +2867,13 @@ release_osx_x86_64_download_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_osx_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2644,6 +2931,13 @@ release_osx_x86_64_macosx-toolchain_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_osx_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2708,6 +3002,13 @@ release_osx_x86_64_macosx-toolchain_2_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_osx_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2772,6 +3073,13 @@ release_osx_x86_64_goeasyconfig_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_osx_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2836,6 +3144,13 @@ release_osx_x86_64_ncdns_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_osx_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2900,6 +3215,13 @@ release_osx_x86_64_ncp11_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_osx_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -2964,6 +3286,13 @@ release_osx_x86_64_ncprop279_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_osx_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -3028,6 +3357,13 @@ release_osx_x86_64_plain-binaries_1_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_osx_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -3092,6 +3428,13 @@ release_osx_x86_64_release_nosign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_osx_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:
@@ -3159,6 +3502,13 @@ release_osx_x86_64_release_sign_docker_builder:
     reupload_on_changes: true
     populate_script:
       - "mkdir -p out_cache2"
+  out3_release_osx_x86_64_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - "echo out3_release_osx_x86_64"
+    reupload_on_changes: true
+    populate_script:
+      - "mkdir -p out_cache3"
   git_release_osx_x86_64_cache:
     folder: git_clones
     fingerprint_script:

--- a/tools/cirrus_build_project.sh
+++ b/tools/cirrus_build_project.sh
@@ -38,6 +38,7 @@ echo "Patching rbm..."
 
 echo "Restoring caches..."
 cp -a ./out_cache1/* ./out/ || true
+cp -a ./out_cache2/* ./out/ || true
 
 echo "Unpacking interrupted cache..."
 ./tools/cirrus_unpack_interrupted.sh || true
@@ -105,7 +106,9 @@ rm -rfv out/container-image
 
 echo "Splitting caches..."
 rsync -avu --delete ./out/macosx-toolchain ./out_cache1/ || true
+rsync -avu --delete ./out/plain-binaries ./out_cache2/ || true
 rm -rf ./out/macosx-toolchain || true
+rm -rf ./out/plain-binaries || true
 
 echo "Packing git cache..."
 ./tools/cirrus_pack_git.sh || true

--- a/tools/cirrus_build_project.sh
+++ b/tools/cirrus_build_project.sh
@@ -39,6 +39,7 @@ echo "Patching rbm..."
 echo "Restoring caches..."
 cp -a ./out_cache1/* ./out/ || true
 cp -a ./out_cache2/* ./out/ || true
+cp -a ./out_cache3/* ./out/ || true
 
 echo "Unpacking interrupted cache..."
 ./tools/cirrus_unpack_interrupted.sh || true
@@ -105,8 +106,10 @@ echo "Cleaning containers..."
 rm -rfv out/container-image
 
 echo "Splitting caches..."
-rsync -avu --delete ./out/macosx-toolchain ./out_cache1/ || true
-rsync -avu --delete ./out/plain-binaries ./out_cache2/ || true
+rsync -avu --delete ./out/encaya ./out/gocrosssign ./out/gosafetlsa ./out/q ./out_cache1/ || true
+rsync -avu --delete ./out/macosx-toolchain ./out_cache2/ || true
+rsync -avu --delete ./out/plain-binaries ./out_cache3/ || true
+rm -rf ./out/encaya ./out/gocrosssign ./out/gosafetlsa ./out/q || true
 rm -rf ./out/macosx-toolchain || true
 rm -rf ./out/plain-binaries || true
 

--- a/tools/cirrus_gen_yml.sh
+++ b/tools/cirrus_gen_yml.sh
@@ -24,6 +24,13 @@ print_os_arch () {
     reupload_on_changes: true
     populate_script:
       - \"mkdir -p out_cache1\"
+  out2_${CHANNEL}_${OS}_${ARCH}_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - \"echo out2_${CHANNEL}_${OS}_${ARCH}\"
+    reupload_on_changes: true
+    populate_script:
+      - \"mkdir -p out_cache2\"
   git_${CHANNEL}_${OS}_${ARCH}_cache:
     folder: git_clones
     fingerprint_script:
@@ -93,6 +100,13 @@ print_os_arch () {
     reupload_on_changes: true
     populate_script:
       - \"mkdir -p out_cache1\"
+  out2_${CHANNEL}_${OS}_${ARCH}_cache:
+    folder: out_cache2
+    fingerprint_script:
+      - \"echo out2_${CHANNEL}_${OS}_${ARCH}\"
+    reupload_on_changes: true
+    populate_script:
+      - \"mkdir -p out_cache2\"
   git_${CHANNEL}_${OS}_${ARCH}_cache:
     folder: git_clones
     fingerprint_script:

--- a/tools/cirrus_gen_yml.sh
+++ b/tools/cirrus_gen_yml.sh
@@ -31,6 +31,13 @@ print_os_arch () {
     reupload_on_changes: true
     populate_script:
       - \"mkdir -p out_cache2\"
+  out3_${CHANNEL}_${OS}_${ARCH}_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - \"echo out3_${CHANNEL}_${OS}_${ARCH}\"
+    reupload_on_changes: true
+    populate_script:
+      - \"mkdir -p out_cache3\"
   git_${CHANNEL}_${OS}_${ARCH}_cache:
     folder: git_clones
     fingerprint_script:
@@ -107,6 +114,13 @@ print_os_arch () {
     reupload_on_changes: true
     populate_script:
       - \"mkdir -p out_cache2\"
+  out3_${CHANNEL}_${OS}_${ARCH}_cache:
+    folder: out_cache3
+    fingerprint_script:
+      - \"echo out3_${CHANNEL}_${OS}_${ARCH}\"
+    reupload_on_changes: true
+    populate_script:
+      - \"mkdir -p out_cache3\"
   git_${CHANNEL}_${OS}_${ARCH}_cache:
     folder: git_clones
     fingerprint_script:


### PR DESCRIPTION
Should improve the odds of the output caches being unmodified, which will save us some upload time.