### PR TITLE
ncdns: Remove tlsrestrictchromium

### DIFF
--- a/projects/ncdns/build
+++ b/projects/ncdns/build
@@ -88,7 +88,7 @@ cd /var/tmp/dist
   done
 
   [% IF c("var/enable_namecoin_tlsa") %]
-    for x in ncdumpzone tlsrestrict_chromium_tool; do
+    for x in ncdumpzone; do
       cp -a $GOPATHBIN/"$x"[% IF c("var/windows") %].exe[% END %] $distdir/
     done
   [% END %]

--- a/projects/ncdns/config
+++ b/projects/ncdns/config
@@ -46,8 +46,6 @@ var:
     - github.com/namecoin/ncdns/ncdumpzone/ncdumpzone
     - github.com/namecoin/ncdns/tlsoverridefirefox
     - github.com/namecoin/ncdns/tlsoverridefirefox/tlsoverridefirefoxsync
-    - github.com/namecoin/ncdns/tlsrestrictchromium
-    - github.com/namecoin/ncdns/tlsrestrictchromium/tlsrestrict_chromium_tool
 
 targets:
   linux:


### PR DESCRIPTION
Package is deprecated and was factored out into its own repo.