### PR TITLE
ncdns-nsis: Add Electrum-NMC dependency

### DIFF
--- a/projects/ncdns-nsis/build
+++ b/projects/ncdns-nsis/build
@@ -44,8 +44,19 @@ cp $rootdir/[% c('input_files_by_name/dnssec-trigger') %] ${ARTIFACTS}
 
 cp $rootdir/[% c('input_files_by_name/consensusj-namecoin') %] ${ARTIFACTS}/bitcoinj-daemon.jar
 
+# Windows PE metadata requires that the version be a dot-delimited 4-tuple of
+# numbers (no leading v)
+NCDNS_NSIS_VERSION=[% c('version') %]
+# Remove leading v
+NCDNS_NSIS_VERSION=$(echo "${NCDNS_NSIS_VERSION}" | sed 's/^v//')
+# Append ".0" until the version is a 4-tuple
+while ! echo "${NCDNS_NSIS_VERSION}" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'
+do
+  NCDNS_NSIS_VERSION=$(echo "${NCDNS_NSIS_VERSION}" | sed 's/$/.0/')
+done
+
 mkdir -p build/bin
-makensis ${NSISFLAGS} -DPOSIX_BUILD=1 -DNCDNS_PRODVER=[% c('var/ncdns_nsis_version') %] [% c('var/arch_nsis_args') %] "-DARTIFACTS=$ARTIFACTS" "-DNEUTRAL_ARTIFACTS=$NEUTRAL_ARTIFACTS" "-DDNSSEC_TRIGGER_FN=[% c('input_files_by_name/dnssec-trigger') %]" "-DNAMECOIN_FN=[% c('input_files_by_name/namecoin-core') %]" "-DOUTFN=${OUTFN}" ncdns.nsi
+makensis ${NSISFLAGS} -DPOSIX_BUILD=1 -DNCDNS_PRODVER=${NCDNS_NSIS_VERSION} [% c('var/arch_nsis_args') %] "-DARTIFACTS=$ARTIFACTS" "-DNEUTRAL_ARTIFACTS=$NEUTRAL_ARTIFACTS" "-DDNSSEC_TRIGGER_FN=[% c('input_files_by_name/dnssec-trigger') %]" "-DNAMECOIN_FN=[% c('input_files_by_name/namecoin-core') %]" "-DOUTFN=${OUTFN}" ncdns.nsi
 
 # Working around NSIS braindamage
 mv "${OUTFN}" torbrowser-install-tmp.exe

--- a/projects/ncdns-nsis/build
+++ b/projects/ncdns-nsis/build
@@ -43,6 +43,7 @@ cp $rootdir/[% c('input_files_by_name/dnssec-trigger') %] ${ARTIFACTS}
 [% END %]
 
 cp $rootdir/[% c('input_files_by_name/consensusj-namecoin') %] ${ARTIFACTS}/bitcoinj-daemon.jar
+cp $rootdir/[% c('input_files_by_name/electrum-nmc') %] ${ARTIFACTS}
 
 # Windows PE metadata requires that the version be a dot-delimited 4-tuple of
 # numbers (no leading v)
@@ -56,7 +57,7 @@ do
 done
 
 mkdir -p build/bin
-makensis ${NSISFLAGS} -DPOSIX_BUILD=1 -DNCDNS_PRODVER=${NCDNS_NSIS_VERSION} [% c('var/arch_nsis_args') %] "-DARTIFACTS=$ARTIFACTS" "-DNEUTRAL_ARTIFACTS=$NEUTRAL_ARTIFACTS" "-DDNSSEC_TRIGGER_FN=[% c('input_files_by_name/dnssec-trigger') %]" "-DNAMECOIN_FN=[% c('input_files_by_name/namecoin-core') %]" "-DOUTFN=${OUTFN}" ncdns.nsi
+makensis ${NSISFLAGS} -DPOSIX_BUILD=1 -DNCDNS_PRODVER=${NCDNS_NSIS_VERSION} [% c('var/arch_nsis_args') %] "-DARTIFACTS=$ARTIFACTS" "-DNEUTRAL_ARTIFACTS=$NEUTRAL_ARTIFACTS" "-DDNSSEC_TRIGGER_FN=[% c('input_files_by_name/dnssec-trigger') %]" "-DNAMECOIN_FN=[% c('input_files_by_name/namecoin-core') %]" "-DELECTRUM_NMC_FN=[% c('input_files_by_name/electrum-nmc') %]" "-DOUTFN=${OUTFN}" ncdns.nsi
 
 # Working around NSIS braindamage
 mv "${OUTFN}" torbrowser-install-tmp.exe

--- a/projects/ncdns-nsis/config
+++ b/projects/ncdns-nsis/config
@@ -11,9 +11,6 @@ var:
   consensusj_namecoin_version: '0.3.2.1'
   dnssec_trigger_version: '0.17'
   namecoin_core_version: '0.21.0.1'
-  # Used for PE metadata.
-  # Must be a 4-tuple without leading 'v' for NSIS to be happy.
-  ncdns_nsis_version: '0.1.2.0'
   container:
     use_container: 1
   deps:

--- a/projects/ncdns-nsis/config
+++ b/projects/ncdns-nsis/config
@@ -11,6 +11,7 @@ var:
   consensusj_namecoin_version: '0.3.2.1'
   dnssec_trigger_version: '0.17'
   namecoin_core_version: '0.21.0.1'
+  electrum_nmc_version: '3.3.10'
   container:
     use_container: 1
   deps:
@@ -44,6 +45,9 @@ input_files:
     URL: 'https://www.namecoin.org/files/namecoin-core/namecoin-core-[% c("var/namecoin_core_version") %]/namecoin-nc[% c("var/namecoin_core_version") %]-win64-setup-unsigned.exe'
     sha256sum: f82c070daa086c2243d641bb07a31d6dc272e191a7792860974d0cd1f0b97873
     enable: '[% c("var/windows-x86_64") %]'
+  - name: electrum-nmc
+    URL: 'https://www.namecoin.org/files/electrum-nmc/electrum-nmc-[% c("var/electrum_nmc_version") %]/electrum-nmc-nc[% c("var/electrum_nmc_version") %]-setup.exe'
+    sha256sum: e7cdd9ed966a2fc8058c14b5ff26431a13899159fe519136bf98c2b0769bfa7d
   - name: consensusj-namecoin
     URL: 'https://www.namecoin.org/files/ConsensusJ-Namecoin/[% c("var/consensusj_namecoin_version") %]/namecoinj-daemon-0.3.2-SNAPSHOT.jar'
     sha256sum: 6b35d5a31eb74b4870c8a6c37dd53563aa63b64810fdedb5192f2a77396e190f


### PR DESCRIPTION
We now chainload Electrum-NMC setup from ncdns-nsis.  Also avoid hardcoded PE version constant.